### PR TITLE
카테고리 테스트 실패하여 원인 수정

### DIFF
--- a/src/test/java/kr/kro/moonlightmoist/shopapi/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/kr/kro/moonlightmoist/shopapi/category/repository/CategoryRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@EnableJpaAuditing
 class CategoryRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
- Auditing 기능 추가후 카테고리테스트가 실패하게 되었다. @EnableJpaAuditing 을 붙이지 않았던것
그래서 @EnableJpaAuditing을 붙여주어서 테스트 성공 하도록 함