### PR TITLE
[백엔드] 브랜드, 카테고리 등록, 조회 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/controller/BrandController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/controller/BrandController.java
@@ -1,0 +1,41 @@
+package kr.kro.moonlightmoist.shopapi.brand.controller;
+
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
+import kr.kro.moonlightmoist.shopapi.brand.service.BrandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/brands")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*",
+        methods = {org.springframework.web.bind.annotation.RequestMethod.GET,
+                org.springframework.web.bind.annotation.RequestMethod.POST,
+                org.springframework.web.bind.annotation.RequestMethod.PUT,
+                org.springframework.web.bind.annotation.RequestMethod.DELETE,
+                org.springframework.web.bind.annotation.RequestMethod.OPTIONS})
+@RequiredArgsConstructor
+public class BrandController {
+
+    private final BrandService brandService;
+
+    @PostMapping("")
+    public ResponseEntity<String> register(@RequestBody BrandDTO dto) {
+        System.out.println("dto = " + dto);
+        brandService.register(dto);
+
+        return ResponseEntity.ok("ok");
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<BrandDTO>> getBrandList() {
+        List<BrandDTO> brands = brandService.getBrandList();
+
+        return ResponseEntity.ok(brands);
+    }
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/domain/Brand.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/domain/Brand.java
@@ -1,6 +1,7 @@
 package kr.kro.moonlightmoist.shopapi.brand.domain;
 
 import jakarta.persistence.*;
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import lombok.*;
 
@@ -23,7 +24,8 @@ public class Brand extends BaseTimeEntity {
     private String name;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
+    @Builder.Default
+    private boolean deleted = false;
 
     public void changeName(String name) {
         this.name = name;
@@ -33,4 +35,11 @@ public class Brand extends BaseTimeEntity {
         this.deleted = true;
     }
 
+    public BrandDTO toDTO() {
+        return BrandDTO.builder()
+                .id(this.id)
+                .name(this.name)
+                .deleted(this.deleted)
+                .build();
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/dto/BrandDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/dto/BrandDTO.java
@@ -1,0 +1,23 @@
+package kr.kro.moonlightmoist.shopapi.brand.dto;
+
+import kr.kro.moonlightmoist.shopapi.brand.domain.Brand;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class BrandDTO {
+    private Long id;
+    private String name;
+    private boolean deleted;
+
+    public Brand toEntity() {
+        return Brand.builder()
+                .name(this.name)
+                .deleted(this.deleted)
+                .build();
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/repository/BrandRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/repository/BrandRepository.java
@@ -3,9 +3,11 @@ package kr.kro.moonlightmoist.shopapi.brand.repository;
 import kr.kro.moonlightmoist.shopapi.brand.domain.Brand;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BrandRepository extends JpaRepository<Brand, Long> {
 
     Optional<Brand> findByName(String name);
+    List<Brand> findByDeletedFalse();
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/service/BrandService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/service/BrandService.java
@@ -1,0 +1,11 @@
+package kr.kro.moonlightmoist.shopapi.brand.service;
+
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
+
+import java.util.List;
+
+public interface BrandService {
+
+    void register(BrandDTO dto);
+    List<BrandDTO> getBrandList();
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/brand/service/BrandServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/brand/service/BrandServiceImpl.java
@@ -1,0 +1,31 @@
+package kr.kro.moonlightmoist.shopapi.brand.service;
+
+import kr.kro.moonlightmoist.shopapi.brand.domain.Brand;
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
+import kr.kro.moonlightmoist.shopapi.brand.repository.BrandRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class BrandServiceImpl implements BrandService{
+
+    private final BrandRepository brandRepository;
+
+    @Override
+    public void register(BrandDTO dto) {
+        Brand brand = dto.toEntity();
+        brandRepository.save(brand);
+    }
+
+    @Override
+    public List<BrandDTO> getBrandList() {
+        List<Brand> brands = brandRepository.findByDeletedFalse();
+        List<BrandDTO> dtos = brands.stream().map(brand -> brand.toDTO()).toList();
+        return dtos;
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/controller/CategoryController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/controller/CategoryController.java
@@ -1,0 +1,43 @@
+package kr.kro.moonlightmoist.shopapi.category.controller;
+
+import kr.kro.moonlightmoist.shopapi.category.domain.Category;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*",
+        methods = {org.springframework.web.bind.annotation.RequestMethod.GET,
+                org.springframework.web.bind.annotation.RequestMethod.POST,
+                org.springframework.web.bind.annotation.RequestMethod.PUT,
+                org.springframework.web.bind.annotation.RequestMethod.DELETE,
+                org.springframework.web.bind.annotation.RequestMethod.OPTIONS})
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping("")
+    public ResponseEntity<String> register(@RequestBody CategoryRegisterReq dto) {
+        System.out.println("dto = " + dto);
+        categoryService.register(dto);
+
+        return ResponseEntity.ok("ok");
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<CategoryRes>> getCategoryList() {
+        List<CategoryRes> categories = categoryService.getCategoryList();
+
+        return ResponseEntity.ok(categories);
+    }
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/domain/Category.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/domain/Category.java
@@ -1,10 +1,12 @@
 package kr.kro.moonlightmoist.shopapi.category.domain;
 
 import jakarta.persistence.*;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -23,6 +25,10 @@ public class Category extends BaseTimeEntity {
     @JoinColumn(name = "parent_id")
     private Category parent;
 
+    @OneToMany(mappedBy = "parent")
+    @Builder.Default
+    private List<Category> subCategories = new ArrayList<>();
+
     @Column(unique = true, nullable = false)
     private String name;
 
@@ -33,7 +39,8 @@ public class Category extends BaseTimeEntity {
     private int displayOrder;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
+    @Builder.Default
+    private boolean deleted = false;
 
     public void changeName(String name) {
         this.name = name;
@@ -45,6 +52,17 @@ public class Category extends BaseTimeEntity {
 
     public void recoverCategory() {
         this.deleted = false;
+    }
+
+//    toDTO 가 subScategories 도 DTO 로 바꿔줘야 함
+    public CategoryRes toDTO() {
+        return CategoryRes.builder()
+                .id(this.id)
+                .subCategories(this.subCategories.stream().map(category -> category.toDTO()).toList())
+                .name(this.name)
+                .depth(this.depth)
+                .displayOrder(this.displayOrder)
+                .build();
     }
 
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRegisterReq.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRegisterReq.java
@@ -1,0 +1,30 @@
+package kr.kro.moonlightmoist.shopapi.category.dto;
+
+import kr.kro.moonlightmoist.shopapi.category.domain.Category;
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CategoryRegisterReq {
+    private Long id;
+    private Category parent;
+    private String name;
+    private int depth;
+    private int displayOrder;
+    private boolean deleted;
+
+    public Category toEntity() {
+        return Category.builder()
+                .parent(this.parent)
+                .name(this.name)
+                .depth(this.depth)
+                .displayOrder(this.displayOrder)
+                .deleted(this.deleted)
+                .build();
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRes.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRes.java
@@ -1,0 +1,21 @@
+package kr.kro.moonlightmoist.shopapi.category.dto;
+
+import kr.kro.moonlightmoist.shopapi.category.domain.Category;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CategoryRes {
+    private Long id;
+    private List<CategoryRes> subCategories;
+    private String name;
+    private int depth;
+    private int displayOrder;
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/repository/CategoryRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/repository/CategoryRepository.java
@@ -3,9 +3,11 @@ package kr.kro.moonlightmoist.shopapi.category.repository;
 import kr.kro.moonlightmoist.shopapi.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByName(String name);
+    List<Category> findByDepthAndDeletedFalse(int depth);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryService.java
@@ -1,0 +1,11 @@
+package kr.kro.moonlightmoist.shopapi.category.service;
+
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+
+import java.util.List;
+
+public interface CategoryService {
+    void register(CategoryRegisterReq dto);
+    List<CategoryRes> getCategoryList();
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryServiceImpl.java
@@ -1,0 +1,31 @@
+package kr.kro.moonlightmoist.shopapi.category.service;
+
+import kr.kro.moonlightmoist.shopapi.category.domain.Category;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService{
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public void register(CategoryRegisterReq dto) {
+        Category category = dto.toEntity();
+        categoryRepository.save(category);
+    }
+
+    @Override
+    public List<CategoryRes> getCategoryList() {
+        List<CategoryRes> categoryResList = categoryRepository.findByDepthAndDeletedFalse(0)
+                .stream().map(category -> category.toDTO()).toList();
+        return categoryResList;
+    }
+
+}


### PR DESCRIPTION
- BrandController 등록, 조회 기능 구현
- Brand 안에 toDTO 메서드 구현, deleted 는 false 가 Default
- BrandDTO생성 및 toEntity 메서드 구현
- BrandRepository 에 findByDeletedFalse() 쿼리메서드 생성
- BrandService 생성
- BrandServiceImpl 구현
- CategoryController 등록, 조회 api 기능 구현
- Category 안에 toDTO 메서드 구현 및 deleted 는 false 가 Default
  - Category 에 subCategories 필드 추가 @OneToMany 적용
- CategoryRegisterReq : 카테고리 등록 요청 DTO 생성
- CategoryRes : 카테고리 응답 DTO 생성
- CategoryRepository 에 findByDepthAndDeletedFalse 쿼리메서드 생성
- CategoryService 인터페이스 생성
- CategoryServiceImpl 에서 메서드 기능 구현