### PR TITLE
[백엔드] 리뷰 목록 조회 - 정렬옵션, 평균별점(평점) 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewController.java
@@ -22,8 +22,11 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @GetMapping("/product/{productId}")
-    public ResponseEntity<List<ReviewDTO>> getList(@PathVariable("productId") Long productId){
-        List<ReviewDTO> reviews = reviewService.getList(productId);
+    public ResponseEntity<List<ReviewDTO>> getList(
+            @PathVariable("productId") Long productId,
+            @RequestParam(defaultValue = "sort") String sort
+            ){
+        List<ReviewDTO> reviews = reviewService.getList(productId, sort);
         return ResponseEntity.ok(reviews);
     }
 
@@ -33,7 +36,7 @@ public class ReviewController {
         return ResponseEntity.ok(reviews);
     }
 
-    @PostMapping("/reviewAdd")
+    @PostMapping("/add")
     public ResponseEntity<ReviewDTO> register(@RequestBody ReviewDTO dto){
         Long id = reviewService.register(dto);
         ReviewDTO reviewDTO = ReviewDTO.builder()
@@ -46,7 +49,7 @@ public class ReviewController {
         return ResponseEntity.ok(reviewDTO);
     }
 
-    @PutMapping("/{reviewId}")
+    @PutMapping("/modify/{reviewId}")
     public ResponseEntity<ReviewDTO> modify(@PathVariable("reviewId") Long reviewId, @RequestBody ReviewDTO dto){
         ReviewDTO reviewUpdated = ReviewDTO.builder()
                 .id(reviewId)
@@ -57,7 +60,7 @@ public class ReviewController {
         return ResponseEntity.ok(modifyReview);
     }
 
-    @DeleteMapping("/{reviewId}")
+    @DeleteMapping("/delete/{reviewId}")
     public Map<String,String> remove(@PathVariable("reviewId") Long reviewId){
         reviewService.remove(reviewId);
         return Map.of("RESULT","SUCCESS");

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/ReviewDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/ReviewDTO.java
@@ -1,15 +1,10 @@
 package kr.kro.moonlightmoist.shopapi.review.dto;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import kr.kro.moonlightmoist.shopapi.product.domain.Product;
-import kr.kro.moonlightmoist.shopapi.user.domain.User;
 import lombok.*;
-import org.hibernate.annotations.Check;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +19,9 @@ public class ReviewDTO {
     private String content;
     private int rating;
     private Long userId;
+    private String loginId;
     private Long productId;
+    private LocalDateTime createdAt;
 
     @Builder.Default
     private List<MultipartFile> files = new ArrayList<>();

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ReviewService {
 
-    List<ReviewDTO> getList(Long productId);//임시 리뷰 목록
+    List<ReviewDTO> getList(Long productId, String sort);
     List<ReviewDTO> getListByUser(Long userId);
     Long register(ReviewDTO dto);
     ReviewDTO modify(ReviewDTO reviewDTO);

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewServiceImpl.java
@@ -41,20 +41,40 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
-    public List<ReviewDTO> getList(Long productId) {
+    public List<ReviewDTO> getList(Long productId, String sort) {
         List<Review> reviews = reviewRepository.findByProductId(productId);
 
-        List<ReviewDTO> reviewDto = reviews.stream().map(review -> {
+        if (sort.equals("latest")) {
+            reviews.sort((r1, r2) -> r2.getCreatedAt().compareTo(r1.getCreatedAt()));
+        } else if (sort.equals("oldest")) {
+            reviews.sort((r1, r2) -> r1.getCreatedAt().compareTo(r2.getCreatedAt()));
+        } else if (sort.equals("ratingDesc")) {
+            reviews.sort((r1, r2) -> {
+                int ratingDesc = r2.getRating() - r1.getRating();
+                if (ratingDesc != 0) return ratingDesc;
+                return r2.getCreatedAt().compareTo(r1.getCreatedAt());
+            }); //내림차순
+        } else if (sort.equals("ratingAsc")) {
+            reviews.sort((r1, r2) -> {
+                int ratingAsc = r1.getRating() - r2.getRating();
+                if (ratingAsc != 0) return ratingAsc;
+                return r1.getCreatedAt().compareTo(r2.getCreatedAt());
+            }); //오름차순
+        }
+
+        List<ReviewDTO> reviewDTO = reviews.stream().map(review -> {
             return ReviewDTO.builder()
                     .id(review.getId())
                     .productId(review.getProduct().getId())
                     .userId(review.getUser().getId())
+                    .loginId(review.getUser().getLoginId())
                     .content(review.getContent())
                     .rating(review.getRating())
+                    .createdAt(review.getCreatedAt())
                     .build();
         }).toList();
 
-        return reviewDto;
+        return reviewDTO;
     }
 
     @Override
@@ -67,6 +87,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .rating(review.getRating())
                         .userId(review.getUser().getId())
                         .productId(review.getProduct().getId())
+                        .createdAt(review.getCreatedAt())
                         .build())
                 .toList();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -122,8 +122,8 @@ VALUES
 INSERT INTO reviews
 (id, user_id, product_id, content, rating, is_visible, is_deleted, created_at, updated_at)
 VALUES
-(1, 1, 1, '리뷰1', 5, true, false, now(), now()),
-(2, 1, 1, '리뷰2', 4, true, false, now(), now()),
-(3, 1, 2, '리뷰3', 3, true, false, now(), now()),
-(4, 2, 2, '리뷰4', 2, true, false, now(), now()),
-(5, 2, 3, '리뷰5', 1, true, false, now(), now());
+(1, 1, 1, '리뷰1', 5, true, false, '2025-11-20 10:00:00', '2025-11-20 10:00:00'),
+(2, 1, 2, '리뷰2', 4, true, false, '2025-11-20 11:30:00', '2025-11-20 11:30:00'),
+(3, 2, 3, '리뷰3', 3, true, false, '2025-11-22 09:15:00', '2025-11-22 09:15:00'),
+(4, 2, 1, '리뷰4', 2, true, false, '2025-11-23 14:45:00', '2025-11-23 14:45:00'),
+(5, 3, 1, '리뷰5', 1, true, false, '2025-11-26 16:20:00', '2025-11-26 16:20:00');


### PR DESCRIPTION
- 리뷰DTO
  - 필요 없는 import 삭제
  - loginId, createAt 필드 추가
- ReviewService
  - getList : sort 인자 추가
- ReviewServiceImpl
  - getList : 리뷰서비스의 getList 수정으로 impl의 getList에 sort인자 추가, sort 로직 추가, reviewDTO builder에 loginId, createAt 추가
- data.sql : 리뷰 임시 데이터 수정
- 리뷰컨트롤러 : 경로 수정 / getList에 sort 추가

리뷰 목록을 최신순(날짜), 별점높은순, 별점낮은순 /
리뷰에 작성한 유저의 아이디와 작성한 날짜를 보기위해 리뷰DTO에 loginId, createAt 추가, 제대로 실행되는지 확인하기 위해 data.sql의 리뷰 더미데이터도 수정했습니다