### PR TITLE
상품 카테고리별 조회 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRes.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryRes.java
@@ -1,6 +1,5 @@
 package kr.kro.moonlightmoist.shopapi.category.dto;
 
-import kr.kro.moonlightmoist.shopapi.category.domain.Category;
 import lombok.*;
 
 import java.util.List;

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package kr.kro.moonlightmoist.shopapi.product.controller;
 import kr.kro.moonlightmoist.shopapi.aws.service.S3UploadService;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
 import kr.kro.moonlightmoist.shopapi.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,5 +67,12 @@ public class ProductController {
 //        System.out.println("id = " + id);
 
         return ResponseEntity.ok("ok");
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<ProductRes>> getProductsByCategory(
+            @RequestParam("categoryId") List<Long> depth3CategoryIds) {
+        List<ProductRes> productResList = productService.searchProductsByCategory(depth3CategoryIds);
+        return ResponseEntity.ok(productResList);
     }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/BasicInfo.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/BasicInfo.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.product.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import kr.kro.moonlightmoist.shopapi.product.dto.BasicInfoDTO;
 import lombok.*;
 
 @Embeddable
@@ -21,4 +22,13 @@ public class BasicInfo {
     private String searchKeywords;
 
     private String description;
+
+    public BasicInfoDTO toDTO() {
+        return BasicInfoDTO.builder()
+                .productName(this.productName)
+                .productCode(this.productCode)
+                .searchKeywords(this.searchKeywords)
+                .description(this.description)
+                .build();
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductMainImage.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductMainImage.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.product.domain;
 
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductMainImageRes;
 import lombok.*;
 
 @Embeddable
@@ -27,4 +28,11 @@ public class ProductMainImage {
         this.displayOrder = ord;
     }
 
+    public ProductMainImageRes toDTO() {
+        return ProductMainImageRes.builder()
+                .imageUrl(this.imageUrl)
+                .displayOrder(this.displayOrder)
+                .imageType(this.imageType)
+                .build();
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.product.domain;
 
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductOptionDTO;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -84,4 +85,17 @@ public class ProductOption extends BaseTimeEntity {
         return Objects.hash(this.getId());
     }
 
+    public ProductOptionDTO toDTO() {
+        return ProductOptionDTO.builder()
+                .id(this.id)
+                .optionName(this.optionName)
+                .purchasePrice(this.purchasePrice)
+                .sellingPrice(this.sellingPrice)
+                .currentStock(this.currentStock)
+                .initialStock(this.initialStock)
+                .safetyStock(this.safetyStock)
+                .imageUrl(this.imageUrl)
+                .displayOrder(this.displayOrder)
+                .build();
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/SaleInfo.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/SaleInfo.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import kr.kro.moonlightmoist.shopapi.product.dto.SaleInfoDTO;
 import lombok.*;
 
 @Embeddable
@@ -26,4 +27,13 @@ public class SaleInfo {
 
     @Column(name = "use_restock_noti", nullable = false)
     private boolean useRestockNoti;
+
+    public SaleInfoDTO toDTO() {
+        return SaleInfoDTO.builder()
+                .exposureStatus(this.exposureStatus)
+                .saleStatus(this.saleStatus)
+                .cancelable(this.cancelable)
+                .useRestockNoti(this.useRestockNoti)
+                .build();
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductMainImageRes.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductMainImageRes.java
@@ -1,0 +1,16 @@
+package kr.kro.moonlightmoist.shopapi.product.dto;
+
+import kr.kro.moonlightmoist.shopapi.product.domain.ImageType;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ProductMainImageRes {
+    private String imageUrl;
+    private int displayOrder;
+    private ImageType imageType;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductOptionDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductOptionDTO.java
@@ -11,12 +11,15 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @ToString
 public class ProductOptionDTO {
+    private Long id;
     private String optionName;
     private int purchasePrice;
     private int sellingPrice;
     private int currentStock;
     private int initialStock;
     private int safetyStock;
+    private String imageUrl;
+    private int displayOrder;
 
     public ProductOption toDomain() {
         return ProductOption.builder()

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductRes.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductRes.java
@@ -1,0 +1,26 @@
+package kr.kro.moonlightmoist.shopapi.product.dto;
+
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.policy.deliveryPolicy.dto.DeliveryPolicyDTO;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ProductRes {
+    private Long id;
+    private CategoryRes category;
+    private BrandDTO brand;
+    private BasicInfoDTO basicInfo;
+    private SaleInfoDTO saleInfo;
+    private DeliveryPolicyDTO deliveryPolicy;
+    private List<ProductOptionDTO> options;
+    private List<ProductMainImageRes> mainImages;
+    private boolean deleted;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/SaleInfoDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/SaleInfoDTO.java
@@ -16,8 +16,8 @@ public class SaleInfoDTO {
     private ExposureStatus exposureStatus;
     private SaleStatus saleStatus;
     @JsonProperty("isCancelable")
-    private boolean cancelable = true;
-    private boolean useRestockNoti = false;
+    private boolean cancelable;
+    private boolean useRestockNoti;
 
     public SaleInfo toDomain() {
         return SaleInfo.builder()

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductRepository.java
@@ -1,14 +1,20 @@
 package kr.kro.moonlightmoist.shopapi.product.repository;
 
 import kr.kro.moonlightmoist.shopapi.product.domain.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p WHERE p.basicInfo.productName = :name")
     Optional<Product> findByProductName(@Param("name") String name);
+
+    // 3차 카테고리 id 리스트로 조회
+    Page<Product> findByCategoryIdIn(List<Long> categoryIds, Pageable pageable);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductService.java
@@ -2,13 +2,17 @@ package kr.kro.moonlightmoist.shopapi.product.service;
 
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
+
+import java.util.List;
 
 public interface ProductService {
     // 상품 등록
     Long register(ProductRequest dto);
     // s3 에 업로드한 이미지 url 추가
     void addImageUrls(Long id, ProductImagesUrlDTO dto);
-    // 상품 조회
+    // 카테고리별 상품 조회
+    List<ProductRes> searchProductsByCategory(List<Long> depth3CategoryIds);
     // 상품 수정
     // 상품 삭제
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
@@ -12,12 +12,18 @@ import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductOptionDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
 import kr.kro.moonlightmoist.shopapi.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -78,4 +84,31 @@ public class ProductServiceImpl implements ProductService{
         }
         System.out.println("product.getMainImages() = " + product.getMainImages());
     }
+
+    @Override
+    public List<ProductRes> searchProductsByCategory(List<Long> depth3CategoryIds) {
+
+        Pageable pageable = PageRequest.of(
+                0,
+                24,
+                Sort.by("id").descending()
+        );
+
+        Page<Product> page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
+
+        List<ProductRes> result = page.get().map(product -> ProductRes.builder()
+                .id(product.getId())
+                .brand(product.getBrand().toDTO())
+                .category(product.getCategory().toDTO())
+                .basicInfo(product.getBasicInfo().toDTO())
+                .saleInfo(product.getSaleInfo().toDTO())
+                .deliveryPolicy(product.getDeliveryPolicy().toDTO())
+                .options(product.getProductOptions().stream().map(option -> option.toDTO()).toList())
+                .mainImages(product.getMainImages().stream().map(image -> image.toDTO()).toList())
+                .build()).toList();
+
+        return result;
+    }
+
+
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -142,7 +142,8 @@ INSERT INTO products (brand_id, category_id, delivery_policy_id, use_restock_not
 (2, 62, 2, TRUE, '[NO.1 미스트세럼] 달바 퍼스트 스프레이 세럼 100ml 2개 기획', 'WHOO_001', '달바 세럼', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW()),
 (3, 63, 2, FALSE, '에스트라 아토베리어365 크림 80ml 기획', 'LANEIGE_001', '에스트라 크림', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW()),
 (4, 64, 2, FALSE, '구달 청귤 비타C 잡티케어 아이크림 30ml 1+1 기획', 'INNIS_001', '구달 아이크림', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW()),
-(5, 71, 2, FALSE, '메디힐 에센셜 마스크팩 1매 고기능 7종 택1', 'TFS_001', '메디힐 마스크팩', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW());
+(5, 71, 2, FALSE, '메디힐 에센셜 마스크팩 1매 고기능 7종 택1', 'TFS_001', '메디힐 마스크팩', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW()),
+(2, 72, 2, FALSE, '[4세대발효콜라겐/4매입] 달바 비타 하이드로겔 마스크 4매입', 'TFS_001', '달바 겔마스크', 'EXPOSURE', 'ON_SALE', '설명 없음', true, false, NOW(), NOW());
 
 
 -- product_main_images 데이터
@@ -166,7 +167,10 @@ INSERT INTO product_main_images (product_id, image_type, display_order, image_ur
 (5, 'GALLERY', 4, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0021/A00000021762036ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5'),
 (5, 'GALLERY', 5, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0021/A00000021762041ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5'),
 (5, 'GALLERY', 6, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0021/A00000021762038ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5'),
-(5, 'GALLERY', 7, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0021/A00000021762037ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5');
+(5, 'GALLERY', 7, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0021/A00000021762037ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5'),
+(6, 'THUMBNAIL', 0, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0022/A00000022879929ko.png?l=ko&QT=100&SF=webp&sharpen=1x0.5'),
+(6, 'GALLERY', 1, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0022/A00000022879925ko.png?l=ko&QT=100&SF=webp&sharpen=1x0.5'),
+(6, 'GALLERY', 2, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0022/A00000022879903ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5');
 
 
 -- product_options 테이블 데이터
@@ -186,7 +190,8 @@ VALUES
 (5, '세라마이드 보습장벽 1매', 500, 1000, 90, 90, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/options/item/2025/1/5177396663963625881.jpg?RS=108x0&QT=85&SF=webp&sharpen=1x0.5', 3, false, NOW(), NOW()),
 (5, '마데카소사이드 흔적리페어 1매', 800, 2000, 70, 70, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/options/item/2025/1/1550813712772282449.jpg?RS=108x0&QT=85&SF=webp&sharpen=1x0.5', 4, false, NOW(), NOW()),
 (5, '로제 PDRN 모공결광 1매', 800, 2000, 90, 90, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/options/item/2025/3/927811821371366876.jpg?RS=108x0&QT=85&SF=webp&sharpen=1x0.5', 5, false, NOW(), NOW()),
-(5, '히알루론산 고밀도 수분 1매', 800, 2000, 70, 70, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/options/item/2025/2/7886183073217244310.jpg?RS=108x0&QT=85&SF=webp&sharpen=1x0.5', 6, false, NOW(), NOW());
+(5, '히알루론산 고밀도 수분 1매', 800, 2000, 70, 70, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/options/item/2025/2/7886183073217244310.jpg?RS=108x0&QT=85&SF=webp&sharpen=1x0.5', 6, false, NOW(), NOW()),
+(6, '달바 비타 하이드로겔 마스크 4매입', 14000, 28000, 70, 70, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0022/A00000022879929ko.png?l=ko&QT=100&SF=webp&sharpen=1x0.5', 0, false, NOW(), NOW());
 
 
 -- 민석 users 테이블에 데이터 삽입 (임시)


### PR DESCRIPTION
- ProductController : GetMapping 으로 getProductsByCategory 메서드 구현, 프론트로부터 3차 카테고리 id 여러개를 쿼리파라미터로 받아서 해당 상품 조회하는 기능
- BasicInfo 에 toDTO 구현
- ProductMainImage 에 toDTO 구현
- ProductOption 에 toDTO 구현
- SaleInfo 에 toDTO 구현
- ProductMainImageRes 구현 (응답용 DTO)
- ProductOptionDTO 에 필드 추가
- ProductRes : 응답용 DTO 작성
- ProductRepository 에 findByCategoryIdIn 쿼리메서드 추가 , 3차카테고리 아이디를 리스트로 받고 pageable 정보를 받아 Page<Product> 로 반환
- ProductService 인터페이스에 searchProductsByCategory 메서드 정의 추가
- ProductServiceImpl 에서 searchProductsByCategory 구현
- data.sql 에 상품 데이터 추가
- 포스트맨으로 3차카테고리로 상품 조회 기능 테스트 정상 작동을 확인함