### PR TITLE
상품 단일 조회시 카테고리정보에 부모 카테고리가 포함되도록 수정

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/controller/CategoryController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/controller/CategoryController.java
@@ -1,8 +1,7 @@
 package kr.kro.moonlightmoist.shopapi.category.controller;
 
-import kr.kro.moonlightmoist.shopapi.category.domain.Category;
 import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
-import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForList;
 import kr.kro.moonlightmoist.shopapi.category.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,8 +33,8 @@ public class CategoryController {
     }
 
     @GetMapping("")
-    public ResponseEntity<List<CategoryRes>> getCategoryList() {
-        List<CategoryRes> categories = categoryService.getCategoryList();
+    public ResponseEntity<List<CategoryResForList>> getCategoryList() {
+        List<CategoryResForList> categories = categoryService.getCategoryList();
 
         return ResponseEntity.ok(categories);
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/domain/Category.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/domain/Category.java
@@ -1,7 +1,8 @@
 package kr.kro.moonlightmoist.shopapi.category.domain;
 
 import jakarta.persistence.*;
-import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForList;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForProductDetail;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import lombok.*;
 
@@ -55,10 +56,28 @@ public class Category extends BaseTimeEntity {
     }
 
 //    toDTO 가 subScategories 도 DTO 로 바꿔줘야 함
-    public CategoryRes toDTO() {
-        return CategoryRes.builder()
+    public CategoryResForList toCategoryResForList() {
+        return CategoryResForList.builder()
                 .id(this.id)
-                .subCategories(this.subCategories.stream().map(category -> category.toDTO()).toList())
+                .subCategories(this.subCategories.stream().map(category -> category.toCategoryResForList()).toList())
+                .name(this.name)
+                .depth(this.depth)
+                .displayOrder(this.displayOrder)
+                .build();
+    }
+
+    public CategoryResForProductDetail toCategoryResForProductDetail() {
+
+        CategoryResForProductDetail parent;
+        if(this.parent == null) {
+            parent = new CategoryResForProductDetail();
+        } else {
+            parent = this.parent.toCategoryResForProductDetail();
+        }
+
+        return CategoryResForProductDetail.builder()
+                .id(this.id)
+                .parent(parent)
                 .name(this.name)
                 .depth(this.depth)
                 .displayOrder(this.displayOrder)

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryResForList.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryResForList.java
@@ -10,11 +10,10 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @ToString
-public class CategoryRes {
+public class CategoryResForList {
     private Long id;
-    private List<CategoryRes> subCategories;
+    private List<CategoryResForList> subCategories;
     private String name;
     private int depth;
     private int displayOrder;
-
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryResForProductDetail.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/dto/CategoryResForProductDetail.java
@@ -1,0 +1,17 @@
+package kr.kro.moonlightmoist.shopapi.category.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CategoryResForProductDetail {
+    private Long id;
+    private CategoryResForProductDetail parent;
+    private String name;
+    private int depth;
+    private int displayOrder;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryService.java
@@ -1,11 +1,11 @@
 package kr.kro.moonlightmoist.shopapi.category.service;
 
 import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
-import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForList;
 
 import java.util.List;
 
 public interface CategoryService {
     void register(CategoryRegisterReq dto);
-    List<CategoryRes> getCategoryList();
+    List<CategoryResForList> getCategoryList();
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/category/service/CategoryServiceImpl.java
@@ -2,7 +2,7 @@ package kr.kro.moonlightmoist.shopapi.category.service;
 
 import kr.kro.moonlightmoist.shopapi.category.domain.Category;
 import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRegisterReq;
-import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForList;
 import kr.kro.moonlightmoist.shopapi.category.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,9 +22,9 @@ public class CategoryServiceImpl implements CategoryService{
     }
 
     @Override
-    public List<CategoryRes> getCategoryList() {
-        List<CategoryRes> categoryResList = categoryRepository.findByDepthAndDeletedFalse(1)
-                .stream().map(category -> category.toDTO()).toList();
+    public List<CategoryResForList> getCategoryList() {
+        List<CategoryResForList> categoryResList = categoryRepository.findByDepthAndDeletedFalse(1)
+                .stream().map(category -> category.toCategoryResForList()).toList();
         return categoryResList;
     }
 

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductController.java
@@ -3,7 +3,8 @@ package kr.kro.moonlightmoist.shopapi.product.controller;
 import kr.kro.moonlightmoist.shopapi.aws.service.S3UploadService;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForDetail;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForList;
 import kr.kro.moonlightmoist.shopapi.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,16 +71,16 @@ public class ProductController {
     }
 
     @GetMapping("")
-    public ResponseEntity<List<ProductRes>> getProductsByCategory(
+    public ResponseEntity<List<ProductResForList>> getProductsByCategory(
             @RequestParam("categoryId") List<Long> depth3CategoryIds) {
-        List<ProductRes> productResList = productService.searchProductsByCategory(depth3CategoryIds);
+        List<ProductResForList> productResList = productService.searchProductsByCategory(depth3CategoryIds);
         return ResponseEntity.ok(productResList);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ProductRes> getProductById(@PathVariable(name = "id") Long id) {
+    public ResponseEntity<ProductResForDetail> getProductById(@PathVariable(name = "id") Long id) {
 
-        ProductRes res = productService.searchProductById(id);
+        ProductResForDetail res = productService.searchProductById(id);
 
         return ResponseEntity.ok(res);
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/Product.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/Product.java
@@ -5,7 +5,8 @@ import kr.kro.moonlightmoist.shopapi.brand.domain.Brand;
 import kr.kro.moonlightmoist.shopapi.category.domain.Category;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import kr.kro.moonlightmoist.shopapi.policy.deliveryPolicy.domain.DeliveryPolicy;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForDetail;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForList;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -98,13 +99,26 @@ public class Product extends BaseTimeEntity {
         }
     }
 
-    public ProductRes toDTO() {
-        return ProductRes.builder()
+    public ProductResForList toDTOForList() {
+        return ProductResForList.builder()
                 .id(this.id)
                 .basicInfo(this.basicInfo.toDTO())
                 .saleInfo(this.saleInfo.toDTO())
                 .brand(this.brand.toDTO())
-                .category(this.category.toDTO())
+                .category(this.category.toCategoryResForList())
+                .deliveryPolicy(this.deliveryPolicy.toDTO())
+                .mainImages(this.mainImages.stream().map(image -> image.toDTO()).toList())
+                .options(this.getProductOptions().stream().map(option -> option.toDTO()).toList())
+                .build();
+    }
+
+    public ProductResForDetail toDTOForDetail() {
+        return ProductResForDetail.builder()
+                .id(this.id)
+                .basicInfo(this.basicInfo.toDTO())
+                .saleInfo(this.saleInfo.toDTO())
+                .brand(this.brand.toDTO())
+                .category(this.category.toCategoryResForProductDetail())
                 .deliveryPolicy(this.deliveryPolicy.toDTO())
                 .mainImages(this.mainImages.stream().map(image -> image.toDTO()).toList())
                 .options(this.getProductOptions().stream().map(option -> option.toDTO()).toList())

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductResForDetail.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductResForDetail.java
@@ -1,7 +1,7 @@
 package kr.kro.moonlightmoist.shopapi.product.dto;
 
 import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
-import kr.kro.moonlightmoist.shopapi.category.dto.CategoryRes;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForProductDetail;
 import kr.kro.moonlightmoist.shopapi.policy.deliveryPolicy.dto.DeliveryPolicyDTO;
 import lombok.*;
 
@@ -13,9 +13,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ProductRes {
+public class ProductResForDetail {
     private Long id;
-    private CategoryRes category;
+    private CategoryResForProductDetail category;
     private BrandDTO brand;
     private BasicInfoDTO basicInfo;
     private SaleInfoDTO saleInfo;

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductResForList.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/ProductResForList.java
@@ -1,0 +1,26 @@
+package kr.kro.moonlightmoist.shopapi.product.dto;
+
+import kr.kro.moonlightmoist.shopapi.brand.dto.BrandDTO;
+import kr.kro.moonlightmoist.shopapi.category.dto.CategoryResForList;
+import kr.kro.moonlightmoist.shopapi.policy.deliveryPolicy.dto.DeliveryPolicyDTO;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ProductResForList {
+    private Long id;
+    private CategoryResForList category;
+    private BrandDTO brand;
+    private BasicInfoDTO basicInfo;
+    private SaleInfoDTO saleInfo;
+    private DeliveryPolicyDTO deliveryPolicy;
+    private List<ProductOptionDTO> options;
+    private List<ProductMainImageRes> mainImages;
+    private boolean deleted;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductService.java
@@ -2,7 +2,8 @@ package kr.kro.moonlightmoist.shopapi.product.service;
 
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForDetail;
+import kr.kro.moonlightmoist.shopapi.product.dto.ProductResForList;
 
 import java.util.List;
 
@@ -12,9 +13,9 @@ public interface ProductService {
     // s3 에 업로드한 이미지 url 추가
     void addImageUrls(Long id, ProductImagesUrlDTO dto);
     // 카테고리별 상품 조회
-    List<ProductRes> searchProductsByCategory(List<Long> depth3CategoryIds);
+    List<ProductResForList> searchProductsByCategory(List<Long> depth3CategoryIds);
     // 상품 단일 조회
-    ProductRes searchProductById(Long id);
+    ProductResForDetail searchProductById(Long id);
     // 상품 수정
     // 상품 삭제
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
@@ -9,10 +9,7 @@ import kr.kro.moonlightmoist.shopapi.policy.deliveryPolicy.repository.DeliveryPo
 import kr.kro.moonlightmoist.shopapi.product.domain.Product;
 import kr.kro.moonlightmoist.shopapi.product.domain.ProductMainImage;
 import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductImagesUrlDTO;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductOptionDTO;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductRequest;
-import kr.kro.moonlightmoist.shopapi.product.dto.ProductRes;
+import kr.kro.moonlightmoist.shopapi.product.dto.*;
 import kr.kro.moonlightmoist.shopapi.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,7 +19,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -86,7 +82,7 @@ public class ProductServiceImpl implements ProductService{
     }
 
     @Override
-    public List<ProductRes> searchProductsByCategory(List<Long> depth3CategoryIds) {
+    public List<ProductResForList> searchProductsByCategory(List<Long> depth3CategoryIds) {
 
         Pageable pageable = PageRequest.of(
                 0,
@@ -95,14 +91,14 @@ public class ProductServiceImpl implements ProductService{
         );
 
         Page<Product> page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
-        List<ProductRes> result = page.get().map(product -> product.toDTO()).toList();
+        List<ProductResForList> result = page.get().map(product -> product.toDTOForList()).toList();
         return result;
     }
 
     @Override
-    public ProductRes searchProductById(Long id) {
+    public ProductResForDetail searchProductById(Long id) {
         Product product = productRepository.findById(id).get();
-        ProductRes dto = product.toDTO();
+        ProductResForDetail dto = product.toDTOForDetail();
         return dto;
     }
 


### PR DESCRIPTION
- 상품 상세페이지에서 해당 상품의 부모 카테고리 정보가 필요했다. 이전 페이지에서 선택한 카테고리 경로를 url 에 덕지덕지 붙일 수도 있지만 상품 조회시 부모 카테고리 정보를 가져오도록 구현 하였다.
- 상품 목록을 위한 카테고리 dto (CategoryResForList) 와 상품 상세 를 위한 카테고리 dto (CategoryResForProductDetail) 를 나눴다.  그리고 Category 의 toDTO 메서드도 2개 로 나뉨
- 상품 목록을 위한 상품 dto (ProductResForList) 와 상품 상세를 위한 상품 dto (ProductResForDetail) 를 나눔, 그리고 Product 의 toDTO 메서드도 2개로 나뉨
- 포스트맨 테스트 정상동작 확인