### PR TITLE
[백엔드] 리뷰 댓글 기능 구현 / OrderProductResponseDTO, OrderServiceImpl 수정

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResponseDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResponseDTO.java
@@ -25,4 +25,7 @@ public class OrderProductResponseDTO {
     private String imageUrl;
     // 상품 주문 상태(주문 접수, 결제완료, 배송준비중, 배송중, 배송완료)
     private OrderProductStatus orderProductStatus;
+
+    // 상품 id
+    private Long productId;
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/service/OrderServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/service/OrderServiceImpl.java
@@ -92,6 +92,7 @@ public class OrderServiceImpl implements OrderService{
         for(OrderProduct op : order.getOrderProducts()){
             OrderProductResponseDTO orderProductResponseDTO = OrderProductResponseDTO.builder()
                     .id(op.getId())
+                    .productId(op.getProductOption().getProduct().getId())
                     .brandName(op.getProductOption().getProduct().getBrand().getName())
                     .productName(op.getProductOption().getProduct().getBasicInfo().getProductName())
                     .productOptionName(op.getProductOption().getOptionName())

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewCommentController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewCommentController.java
@@ -1,0 +1,51 @@
+package kr.kro.moonlightmoist.shopapi.review.controller;
+
+import kr.kro.moonlightmoist.shopapi.review.dto.ReviewCommentDTO;
+import kr.kro.moonlightmoist.shopapi.review.repository.ReviewCommentRepository;
+import kr.kro.moonlightmoist.shopapi.review.service.ReviewCommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/comment")
+@CrossOrigin(origins = "http://localhost:5173")
+public class ReviewCommentController {
+
+    private final ReviewCommentRepository reviewCommentRepository;
+    private final ReviewCommentService reviewCommentService;
+
+    @GetMapping("/{commentId}")
+    public ResponseEntity<List<ReviewCommentDTO>> getList(@PathVariable("commentId") Long commentId) {
+      List<ReviewCommentDTO>  reviewComments = reviewCommentService.getList(commentId);
+      return ResponseEntity.ok(reviewComments);
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<String> register(@RequestBody ReviewCommentDTO dto) {
+      reviewCommentService.register(dto);
+      return ResponseEntity.ok("성공");
+    }
+
+    @PutMapping("/modify/{commentId}")
+    public ResponseEntity<String> modify(
+        @PathVariable("commentId") Long commentId,
+        @RequestBody ReviewCommentDTO dto) {
+
+      dto.setId(commentId);
+      reviewCommentService.modify(dto);
+
+      return ResponseEntity.ok("성공");
+    }
+
+    @DeleteMapping("/delete/{commentId}")
+    public ResponseEntity<String> remove(@PathVariable("commentId") Long commentId) {
+      reviewCommentService.remove(commentId);
+      return ResponseEntity.ok("성공");
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/controller/ReviewController.java
@@ -1,7 +1,6 @@
 package kr.kro.moonlightmoist.shopapi.review.controller;
 
 import kr.kro.moonlightmoist.shopapi.aws.service.S3UploadService;
-import kr.kro.moonlightmoist.shopapi.review.domain.ReviewImage;
 import kr.kro.moonlightmoist.shopapi.review.dto.ReviewDTO;
 import kr.kro.moonlightmoist.shopapi.review.dto.ReviewImageUrlDTO;
 import kr.kro.moonlightmoist.shopapi.review.repository.ReviewRepository;
@@ -92,9 +91,9 @@ public class ReviewController {
     }
 
     @DeleteMapping("/delete/{reviewId}")
-    public Map<String,String> remove(@PathVariable("reviewId") Long reviewId){
+    public ResponseEntity<String> remove(@PathVariable("reviewId") Long reviewId){
         reviewService.remove(reviewId);
-        return Map.of("RESULT","SUCCESS");
+        return ResponseEntity.ok("성공");
     }
 
     @GetMapping("/product/{productId}/avg")

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/domain/ReviewComment.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/domain/ReviewComment.java
@@ -2,9 +2,8 @@ package kr.kro.moonlightmoist.shopapi.review.domain;
 
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import kr.kro.moonlightmoist.shopapi.user.domain.User;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
@@ -33,5 +32,11 @@ public class ReviewComment extends BaseTimeEntity {
     @ManyToOne(optional = false)
     @JoinColumn(name = "review_id")
     private Review review;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public void changeContent(String content) { this.content = content; }
 
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/domain/ReviewImage.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/domain/ReviewImage.java
@@ -1,10 +1,7 @@
 package kr.kro.moonlightmoist.shopapi.review.domain;
 
 import jakarta.persistence.*;
-import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Embeddable
 @NoArgsConstructor

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/ReviewCommentDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/ReviewCommentDTO.java
@@ -1,0 +1,20 @@
+package kr.kro.moonlightmoist.shopapi.review.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@Getter
+@Setter
+public class ReviewCommentDTO {
+  private Long id;
+  private String content;
+  private Long reviewId;
+  private Long userId;
+  private String loginId;
+  private LocalDateTime createAt;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/repository/ReviewCommentRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/repository/ReviewCommentRepository.java
@@ -1,7 +1,12 @@
 package kr.kro.moonlightmoist.shopapi.review.repository;
 
+import kr.kro.moonlightmoist.shopapi.review.domain.Review;
 import kr.kro.moonlightmoist.shopapi.review.domain.ReviewComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewCommentRepository extends JpaRepository<ReviewComment,Long> {
+
+    List<ReviewComment> findByReviewId(Long reviewId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewCommentService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewCommentService.java
@@ -1,0 +1,17 @@
+package kr.kro.moonlightmoist.shopapi.review.service;
+
+import kr.kro.moonlightmoist.shopapi.review.dto.ReviewCommentDTO;
+
+import java.util.List;
+
+public interface ReviewCommentService {
+    //리뷰 댓글 전체 조회
+    List<ReviewCommentDTO> getList(Long reviewId);
+    //리뷰 댓글 등록
+    Long register(ReviewCommentDTO dto);
+    //리뷰 댓글 수정
+    ReviewCommentDTO modify(ReviewCommentDTO dto);
+    //리뷰 댓글 삭제
+    void remove(Long id);
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewCommentServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewCommentServiceImpl.java
@@ -1,0 +1,87 @@
+package kr.kro.moonlightmoist.shopapi.review.service;
+
+import jakarta.transaction.Transactional;
+import kr.kro.moonlightmoist.shopapi.review.domain.Review;
+import kr.kro.moonlightmoist.shopapi.review.domain.ReviewComment;
+import kr.kro.moonlightmoist.shopapi.review.dto.ReviewCommentDTO;
+import kr.kro.moonlightmoist.shopapi.review.repository.ReviewCommentRepository;
+import kr.kro.moonlightmoist.shopapi.review.repository.ReviewRepository;
+import kr.kro.moonlightmoist.shopapi.user.domain.User;
+import kr.kro.moonlightmoist.shopapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ReviewCommentServiceImpl implements ReviewCommentService {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewCommentRepository reviewCommentRepository;
+  private final UserRepository userRepository;
+
+  public Review getReview(Long reviewId) {
+    return reviewRepository.findById(reviewId).get();
+  }
+
+  public User getUser() {
+    return userRepository.findById(3L).get();
+  }
+
+  @Override
+  public List<ReviewCommentDTO> getList(Long reviewId) {
+    List<ReviewComment> reviewComments = reviewCommentRepository.findByReviewId(reviewId);
+
+    List<ReviewCommentDTO> reviewCommentDTO = reviewComments.stream().map(reviewComment -> {
+      return ReviewCommentDTO.builder()
+          .id(reviewComment.getId())
+          .reviewId(reviewComment.getReview().getId())
+          .userId(reviewComment.getUser().getId())
+          .loginId(reviewComment.getReview().getUser().getLoginId())
+          .content(reviewComment.getContent())
+          .createAt(reviewComment.getCreatedAt())
+          .build();
+    }).toList();
+    return reviewCommentDTO;
+  }
+
+  @Override
+  public Long register(ReviewCommentDTO dto) {
+
+    Review review = getReview(dto.getReviewId());
+    User user = getUser();
+
+    ReviewComment reviewComment = ReviewComment.builder()
+        .content(dto.getContent())
+        .review(review)
+        .user(user)
+        .build();
+
+    ReviewComment saveReviewComment = reviewCommentRepository.save(reviewComment);
+
+    return saveReviewComment.getId();
+  }
+
+  @Override
+  public ReviewCommentDTO modify(ReviewCommentDTO dto) {
+    Optional<ReviewComment> foundReviewComment = reviewCommentRepository.findById(dto.getId());
+    ReviewComment reviewComment = foundReviewComment.get();
+
+    reviewComment.changeContent(dto.getContent());
+
+    return ReviewCommentDTO.builder()
+        .content(dto.getContent())
+        .build();
+  }
+
+  @Override
+  public void remove(Long id) {
+      reviewCommentRepository.deleteById(id);
+
+  }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewService.java
@@ -16,7 +16,7 @@ public interface ReviewService {
     //리뷰 수정
     ReviewDTO modify(ReviewDTO reviewDTO);
     //리뷰 삭제
-    void remove(Long reviewId);
+    void remove(Long id);
     //s3 에 업로드한 이미지 url 추가
     void addImageUrls(Long id, ReviewImageUrlDTO dto);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/service/ReviewServiceImpl.java
@@ -1,8 +1,6 @@
 package kr.kro.moonlightmoist.shopapi.review.service;
 
 import jakarta.transaction.Transactional;
-import kr.kro.moonlightmoist.shopapi.brand.repository.BrandRepository;
-import kr.kro.moonlightmoist.shopapi.category.repository.CategoryRepository;
 import kr.kro.moonlightmoist.shopapi.product.domain.Product;
 import kr.kro.moonlightmoist.shopapi.product.repository.ProductRepository;
 import kr.kro.moonlightmoist.shopapi.review.domain.Review;
@@ -27,12 +25,10 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
-    private final CategoryRepository categoryRepository;
-    private final BrandRepository brandRepository;
     private final UserRepository userRepository;
 
-    public Product getProduct() {
-        return productRepository.findById(1L).get();
+    public Product getProduct(Long productId) {
+      return productRepository.findById(productId).get();
     }
 
     public User getUser() {
@@ -104,7 +100,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public Long register(ReviewDTO dto) {
 
-        Product product = getProduct();
+        Product product = getProduct(dto.getProductId());
         User user = getUser();
 
         Review review = Review.builder()
@@ -128,7 +124,7 @@ public class ReviewServiceImpl implements ReviewService {
         review.changeRating(reviewDTO.getRating());
 
         if (reviewDTO.getDeleteImgUrls() != null && !reviewDTO.getDeleteImgUrls().isEmpty()) {
-            review.removeImgUrls(reviewDTO.getDeleteImgUrls());
+          review.removeImgUrls(reviewDTO.getDeleteImgUrls());
         }
 
         List<String> imageUrls = review.getReviewImages().stream()


### PR DESCRIPTION
- 리뷰ServiceImpl getProduct 메서드 수정
  - 기존 고정 id를 productId로 수정
  - productId로 수정후 리뷰 댓글 작성에 오류가 생겼고, 오류 원인이 productId가 넘어오지 않는 문제여서 OrderProductResponseDTO, OrderServiceImpl에서 productId 추가해보니 해결됐습니다.
- OrderProductResponseDTO, OrderServiceImpl
  - 주문내역에서 리뷰 작성시 productId가 undefined로 넘어오는 문제로 productId 필드 추가, toDto 메서드 orderProductResponseDTO에 productId 추가
- 리뷰컨트롤러 일부 수정
- 리뷰댓글DTO, repository, Service, Impl, controller 작성
- 필요 없는 import 삭제