### PR TITLE
[백엔드] 회원가입 사용자ID 중복확인 리팩토링

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/user/controller/UserController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/user/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
     public ResponseEntity<LoginIdCheckResponse> checkLoginId (@RequestParam String loginId) {
         // @requestParam = QueryParameter 값을 추출해서 해당 인자 String loginId로 변환해서 받는다.
         // 프론트 요청에서 Params로 보냈기때문에 즉, 쿼리파라미터로 보냈기 때문에 해당 어노테이션 사용
-        boolean isDuplicate = userService.existsByLoginId(loginId); // service의 existsByLoginId 메서드 사용
+        boolean isDuplicate = userService.checkLoginId(loginId); // service의 existsByLoginId 메서드 사용
         String message = isDuplicate ? "이미 사용 중인 아이디입니다." : "사용 가능한 아이디 입니다.";
 
         LoginIdCheckResponse response = new LoginIdCheckResponse(isDuplicate, message);

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/user/repository/UserRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/user/repository/UserRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByLoginId(String loginId);
-    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/user/service/UserService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/user/service/UserService.java
@@ -9,5 +9,5 @@ import kr.kro.moonlightmoist.shopapi.user.dto.UserSignUpRequest;
 public interface UserService {
     User registerUser(UserSignUpRequest userSignUpRequest);
     UserLoginResponse login(UserLoginRequest userLoginRequest);
-    boolean existsByLoginId(String loginId);
+    boolean checkLoginId(String loginId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/user/service/UserServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/user/service/UserServiceImpl.java
@@ -52,8 +52,17 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean existsByLoginId(String loginId) { // 컨트롤러에서 loginId 받음
-        return userRepository.existsByLoginId(loginId); // 해당 loginId를 DB에서 찾아서 반환해줌
+    public boolean checkLoginId(String loginId) {
+        System.out.println("중복확인 Service");
+        System.out.println("조회한 loginId :" + loginId);
+        Optional<User> findUser = userRepository.findByLoginId(loginId);
+        if(findUser.isPresent()){
+            System.out.println("DB에 해당 유저정보가 있습니다." + findUser.get().getLoginId());
+            return true;
+        } else {
+            System.out.println("DB에 해당 유저정보가 없습니다");
+            return false;
+        }
     }
 
 


### PR DESCRIPTION
기존에 existsByLoginId 의 경우 JPA가 메서드 이름을 읽어들여서 자동으로 해당 내용과 일치하는 메서드로 만들어준다고 하여 해당 기능을 사용하는것은 지금 개발기술에 올바른 방향이 아닌것 같아서 해당 메서드를 삭제. 사용자아이디 중복 확인 로직을 JPA 자동생성 메서드 사용이 아닌, 직접 조회 및 비교하는 로직으로 변경하였음