### PR TITLE
상품 등록시 이미지정보 displayOrder 값 들어가도록 수정

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
@@ -26,7 +26,7 @@ public class ProductOption extends BaseTimeEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = false, nullable = false)
     private String optionName;
 
     @Column(nullable = false)

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
@@ -71,6 +71,7 @@ public class ProductServiceImpl implements ProductService{
 
         for(int i=0; i<dto.getOptionImageUrls().size(); i++) {
             product.getProductOptions().get(i).setImageUrl(dto.getOptionImageUrls().get(i));
+            product.getProductOptions().get(i).setDisplayOrder(i);
         }
         System.out.println("product.getMainImages() = " + product.getMainImages());
         for(int i=0; i<dto.getMainImageUrls().size(); i++) {
@@ -78,6 +79,8 @@ public class ProductServiceImpl implements ProductService{
             product.getMainImages()
                     .add(ProductMainImage.builder()
                             .imageUrl(dto.getMainImageUrls().get(i))
+                            .imageType(i==0 ? ImageType.THUMBNAIL : ImageType.GALLERY)
+                            .displayOrder(i)
                             .build()
                     );
         }
@@ -87,6 +90,7 @@ public class ProductServiceImpl implements ProductService{
             product.getDetailImages()
                     .add(ProductDetailImage.builder()
                             .imageUrl(dto.getDetailImageUrls().get(i))
+                            .displayOrder(i)
                             .build()
                     );
         }


### PR DESCRIPTION
- 상품 이미지, 옵션 등의 정보가 등록될 때 displayOrder 가 저장이 안되었었다. 순서에 맞게 저장되도록 수정
- productOption 의 optionName 이 unique 일 필요는 없는것 같아서 unique = false 로 수정