### PR TITLE
쿠폰 엔티티에 발급횟수 필드 추가 및 쿠폰 발급시 발급회수 +1 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/coupon/domain/Coupon.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/coupon/domain/Coupon.java
@@ -83,9 +83,17 @@ public class Coupon extends BaseTimeEntity {
     @Column(nullable = true)
     private Integer maxDiscountAmount;
 
+    @Column(nullable = true)
+    @Builder.Default
+    private Integer issueCount = 0;
+
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private Boolean deleted = false;
+
+    public void addIssueCount() {
+        this.issueCount +=1;
+    }
 
     public CouponDto toDto() {
         return CouponDto.builder()
@@ -109,6 +117,7 @@ public class Coupon extends BaseTimeEntity {
                 .discountPercentage(this.discountPercentage)
                 .limitMaxDiscountAmount(this.limitMaxDiscountAmount)
                 .maxDiscountAmount(this.maxDiscountAmount)
+                .issueCount(this.issueCount)
                 .build();
     }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/coupon/dto/CouponDto.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/coupon/dto/CouponDto.java
@@ -39,6 +39,7 @@ public class CouponDto {
     @JsonProperty("hasLimitMaxDiscount")
     private Boolean limitMaxDiscountAmount;
     private Integer maxDiscountAmount;
+    private Integer issueCount;
     private Boolean deleted;
 
     public Coupon toEntity() {

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/usercoupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/usercoupon/service/UserCouponServiceImpl.java
@@ -26,6 +26,7 @@ public class UserCouponServiceImpl implements UserCouponService{
     public Long issue(Long userId, Long couponId) {
         User user = userRepository.findById(userId).get();
         Coupon coupon = couponRepository.findById(couponId).get();
+        coupon.addIssueCount();
 
         UserCoupon userCoupon = UserCoupon.builder()
                 .user(user)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -336,13 +336,13 @@ VALUES
 (6, '달바 비타 하이드로겔 마스크 4매입', 14000, 28000, 70, 70, 10, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0022/A00000022879929ko.png?l=ko&QT=100&SF=webp&sharpen=1x0.5', 0, false, NOW(), NOW());
 
 ---- coupons 테이블 데이터 삽임
-INSERT INTO coupons (name, issue_type, auto_issue_type, auto_issue_trigger, coupon_code, total_quantity, issuable_start_date, issuable_end_date, availability, has_limit_usage_period, valid_from, valid_to, has_limit_min_order_amount, min_order_amount, discount_type, fixed_discount_amount, discount_percentage, has_limit_max_discount_amount, max_discount_amount, is_deleted, created_at, updated_at)
+INSERT INTO coupons (name, issue_type, auto_issue_type, auto_issue_trigger, coupon_code, total_quantity, issuable_start_date, issuable_end_date, availability, has_limit_usage_period, valid_from, valid_to, has_limit_min_order_amount, min_order_amount, discount_type, fixed_discount_amount, discount_percentage, has_limit_max_discount_amount, max_discount_amount, issue_count, is_deleted, created_at, updated_at)
 VALUES
-('신규회원 환영 쿠폰', 'AUTO', 'NEWUSER', 'ALL_USER', NULL, 9999999999, NULL, NULL, 'USABLE', FALSE, NULL, NULL, TRUE, 20000, 'FIXED', 3000, NULL, NULL, NULL, FALSE, NOW(), NOW()),
-('겨울맞이 10% 할인 쿠폰', 'AUTO', 'EVENT', 'LOGIN', NULL, 9999999999, '2025-11-01 00:00:00', '2026-01-31 23:59:59', 'USABLE', TRUE, '2025-11-01 00:00:00', '2026-02-28 23:59:59', TRUE, 20000, 'PERCENTAGE', NULL, 10, TRUE, 30000, FALSE, '2025-11-01 00:00:00', '2025-11-01 00:00:00'),
-('운영자가 주는 20% 할인 쿠폰', 'MANUAL', NULL, NULL, NULL, 9999999999, NULL, NULL, 'USABLE', FALSE, NULL, NULL, FALSE, NULL, 'PERCENTAGE', NULL, 20, FALSE, NULL, FALSE, '2025-11-01 00:00:00', '2025-11-01 00:00:00'),
-('카카오톡 친구 환영 10000원 할인 쿠폰', 'CODE', NULL, NULL, 'WELCOME_FRIEND', 9999999999, '2025-12-04 00:00:00', '2026-12-04 00:00:00', 'USABLE', FALSE, NULL, NULL, TRUE, 30000, 'FIXED', 10000, NULL, FALSE, NULL, FALSE, '2025-12-04 00:00:00', '2025-12-04 00:00:00'),
-('오직 크리스마스! 10000원 할인 쿠폰', 'AUTO', 'EVENT', 'LOGIN', NULL, 9999999999, '2025-12-24 00:00:00', '2025-12-25 23:59:59', 'USABLE', TRUE, '2025-12-24 00:00:00', '2025-12-25 23:59:59', TRUE, 20000, 'FIXED', 10000, NULL, FALSE, NULL, FALSE, '2025-12-04 14:42:00', '2025-12-04 14:42:00');
+('신규회원 환영 쿠폰', 'AUTO', 'NEWUSER', 'ALL_USER', NULL, 9999999999, NULL, NULL, 'USABLE', FALSE, NULL, NULL, TRUE, 20000, 'FIXED', 3000, NULL, NULL, NULL, 5, FALSE, NOW(), NOW()),
+('겨울맞이 10% 할인 쿠폰', 'AUTO', 'EVENT', 'LOGIN', NULL, 9999999999, '2025-11-01 00:00:00', '2026-01-31 23:59:59', 'USABLE', TRUE, '2025-11-01 00:00:00', '2026-02-28 23:59:59', TRUE, 20000, 'PERCENTAGE', NULL, 10, TRUE, 30000, 0, FALSE, '2025-11-01 00:00:00', '2025-11-01 00:00:00'),
+('운영자가 주는 20% 할인 쿠폰', 'MANUAL', NULL, NULL, NULL, 9999999999, NULL, NULL, 'USABLE', FALSE, NULL, NULL, FALSE, NULL, 'PERCENTAGE', NULL, 20, FALSE, NULL, 0, FALSE, '2025-11-01 00:00:00', '2025-11-01 00:00:00'),
+('카카오톡 친구 환영 10000원 할인 쿠폰', 'CODE', NULL, NULL, 'WELCOME_FRIEND', 9999999999, '2025-12-04 00:00:00', '2026-12-04 00:00:00', 'USABLE', FALSE, NULL, NULL, TRUE, 30000, 'FIXED', 10000, NULL, FALSE, NULL, 0, FALSE, '2025-12-04 00:00:00', '2025-12-04 00:00:00'),
+('오직 크리스마스! 10000원 할인 쿠폰', 'AUTO', 'EVENT', 'LOGIN', NULL, 9999999999, '2025-12-24 00:00:00', '2025-12-25 23:59:59', 'USABLE', TRUE, '2025-12-24 00:00:00', '2025-12-25 23:59:59', TRUE, 20000, 'FIXED', 10000, NULL, FALSE, NULL, 0, FALSE, '2025-12-04 14:42:00', '2025-12-04 14:42:00');
 
 -- 민석 users 테이블에 데이터 삽입 (임시)
 INSERT INTO users


### PR DESCRIPTION
- 쿠폰 엔티티에 issueCount 필드 추가 default 는 0으로
- CouponDto 에 issueCount 추가
- 쿠폰 발급시 해당 쿠폰의 issueCount 가 +1 되도록 함
- data.sql 의 쿠폰 데이터에 issueCount 값 추가

This Closes #147 