### PR TITLE
[백엔드] 포인트히스토리 엔티티 작성, 포인트 조회, 획득, 사용 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/controller/PointHistoryController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/controller/PointHistoryController.java
@@ -1,0 +1,46 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.controller;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.dto.PointEarnReq;
+import kr.kro.moonlightmoist.shopapi.pointHistory.dto.PointUseReq;
+import kr.kro.moonlightmoist.shopapi.pointHistory.repository.PointHistoryRepository;
+import kr.kro.moonlightmoist.shopapi.pointHistory.service.PointHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/point")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*",
+        methods = {RequestMethod.GET,
+                RequestMethod.POST,
+                RequestMethod.PUT,
+                RequestMethod.DELETE,
+                RequestMethod.OPTIONS})
+@RequiredArgsConstructor
+public class PointHistoryController {
+
+    private final PointHistoryService pointHistoryService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<Integer> getActivePoints(@PathVariable("userId") Long userId) {
+        int activePoint = pointHistoryService.getActivePoint(userId);
+
+        return ResponseEntity.ok(activePoint);
+    }
+
+    @PostMapping("/earn")
+    public ResponseEntity<String> earnPoint(@RequestBody PointEarnReq dto) {
+        pointHistoryService.earnPoint(dto.getUserId(), dto.getPointValue());
+
+        return ResponseEntity.ok("ok");
+    }
+
+    @PostMapping("/use")
+    public ResponseEntity<String> usePoint(@RequestBody PointUseReq dto) {
+        pointHistoryService.usePoint(dto.getUserId(), dto.getAmountToUse());
+
+        return ResponseEntity.ok("ok");
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointHistory.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointHistory.java
@@ -1,0 +1,39 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.domain;
+
+import jakarta.persistence.*;
+import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import kr.kro.moonlightmoist.shopapi.user.domain.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Getter
+@Builder
+@Setter
+@Table(name = "point_histories")
+public class PointHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private PointStatus pointStatus;
+
+    private Integer pointValue;
+    private Integer remainingPoint;
+    private LocalDateTime expiredAt;
+
+    @Column(name = "is_deleted")
+    @Builder.Default
+    private boolean deleted = false;
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointStatus.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointStatus.java
@@ -1,0 +1,5 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.domain;
+
+public enum PointStatus {
+    EARNED,USED,EXPIRED
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/dto/PointEarnReq.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/dto/PointEarnReq.java
@@ -1,0 +1,14 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PointEarnReq {
+    private Long userId;
+    private Integer pointValue;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/dto/PointUseReq.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/dto/PointUseReq.java
@@ -1,0 +1,14 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointUseReq {
+    private Long userId;
+    private Integer amountToUse;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
@@ -1,0 +1,32 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.repository;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+
+    @Query("SELECT p FROM PointHistory p " +
+            "WHERE p.user.id = :userId " +
+            "AND p.pointStatus = 'EARNED' " +
+            "AND p.remainingPoint > 0 " +
+            "AND p.expiredAt > :now " +
+            "ORDER BY p.expiredAt ASC"
+    )
+    List<PointHistory> findAllActivePoints(
+            @Param("userId") Long userId,
+            @Param("now") LocalDateTime now
+    );
+
+    // 누적 포인트
+    @Query("SELECT COALESCE(SUM(p.pointValue), 0) FROM PointHistory p " +
+            "WHERE p.user.id = :userId " +
+            "AND p.pointStatus = 'EARNED'"
+    )
+    Long findCumulativePoints(@Param("userId") Long userId);
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryService.java
@@ -1,0 +1,7 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.service;
+
+public interface PointHistoryService {
+    int getActivePoint(Long userId);
+    void earnPoint(Long userId, int pointValue);
+    void usePoint(Long userId, int amountToUse);
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryServiceImpl.java
@@ -1,0 +1,84 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.service;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointStatus;
+import kr.kro.moonlightmoist.shopapi.pointHistory.repository.PointHistoryRepository;
+import kr.kro.moonlightmoist.shopapi.user.domain.User;
+import kr.kro.moonlightmoist.shopapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PointHistoryServiceImpl implements PointHistoryService{
+
+    private final UserRepository userRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+
+    @Override
+    public int getActivePoint(Long userId) {
+        List<PointHistory> allActivePoints = pointHistoryRepository.findAllActivePoints(userId, LocalDateTime.now());
+        int sum = allActivePoints.stream()
+                .mapToInt(p -> p.getRemainingPoint())
+                .sum();
+        return sum;
+    }
+
+    @Override
+    public void earnPoint(Long userId, int pointValue) {
+        User user = userRepository.findById(userId).get();
+
+        PointHistory pointHistory = PointHistory.builder()
+                .user(user)
+                .pointStatus(PointStatus.EARNED)
+                .pointValue(pointValue)
+                .remainingPoint(pointValue)
+                .expiredAt(LocalDateTime.now().plusYears(1))
+                .build();
+        pointHistoryRepository.save(pointHistory);
+    }
+
+    @Override
+    @Transactional
+    public void usePoint(Long userId, int amountToUse) {
+        // 유효기간 얼마 안남은 순서로 가져옴
+        List<PointHistory> allActivePoints = pointHistoryRepository.findAllActivePoints(userId, LocalDateTime.now());
+
+        int totalBalance = allActivePoints.stream().mapToInt(p -> p.getRemainingPoint()).sum();
+        if (totalBalance < amountToUse) {
+            throw new RuntimeException("잔여 포인트가 사용하려는 포인트보다 적습니다.");
+        }
+
+        int remainingAmountToUse = amountToUse;
+
+        for (PointHistory history : allActivePoints) {
+            int availablePoint = history.getRemainingPoint();
+
+            if (availablePoint >= remainingAmountToUse) {
+                // 이 내역 하나로 충분할 때
+                history.setRemainingPoint(availablePoint - remainingAmountToUse);
+                remainingAmountToUse = 0;
+                break;
+            } else {
+                // 이 내역을 다 써도 부족할 때 (부분 차감)
+                history.setRemainingPoint(0);
+                remainingAmountToUse -= availablePoint;
+            }
+        }
+
+        User user = userRepository.findById(userId).get();
+        // 사용 history 를 남겨야함
+        PointHistory usageHistory = PointHistory.builder()
+                .user(user)
+                .pointStatus(PointStatus.EARNED)
+                .pointValue(-amountToUse)
+                .remainingPoint(0)
+                .build();
+        pointHistoryRepository.save(usageHistory);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -357,6 +357,15 @@ VALUES
 (6,'user','a','유저','01012345677','user@naver.com','2025-12-08','12345','성남시 미금역','그린아카데미',false,true,false,NULL,'USER','BRONZE',NOW(),NOW()),
 (7,'admin','a','관리자','01012345678','admin@naver.com','2025-12-08','12345','성남시 미금역','그린아카데미',false,true,false,NULL,'ADMIN','VIP',NOW(),NOW());
 
+
+-- 포인트 히스토리
+INSERT INTO point_histories
+(user_id, point_status, point_value, remaining_point, expired_at, is_deleted, created_at, updated_at) VALUES
+(1, 'EARNED', 100, 100, '2026-12-01 00:00:00', FALSE, '2025-12-01 00:00:00', '2025-12-01 00:00:00'),
+(1, 'EARNED', 100, 100, '2026-12-01 00:05:00', FALSE, '2025-12-01 00:05:00', '2025-12-01 00:05:00'),
+(1, 'EXPIRED', 100, 100, '2024-12-01 00:05:00', FALSE, '2023-12-01 00:05:00', '2024-12-01 00:05:00');
+
+
 -- 발급받은 유저 쿠폰
 INSERT INTO user_coupons (user_id, coupon_id, usage_status, used_at, is_deleted, created_at, updated_at)
 VALUES


### PR DESCRIPTION
- 포인트히스토리 엔티티 작성
- 포인트 조회 : userId 를 인자로 받아 해당 유저의 사용가능한 포인트의 합을 반환
- 포인트 획득 : 획득 포인트는 1년 뒤 만료되도록 설정함
- 포인트 소비 : remainingPoint 필드를 이용해서 부분차감까지 기능 구현, EARNED 인 row 는 remainingPoint 가 차감되고 마지막에 USED row가 얼마 포인트를 사용했는지 기록으로 남도록 함
- 포스트맨으로 조회, 획득, 소비 기능을 테스트함