### PR TITLE
스프링 스케줄러를 이용해 포인트 만료 처리 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/MoonlightMoistShopApiServerApplication.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/MoonlightMoistShopApiServerApplication.java
@@ -2,8 +2,10 @@ package kr.kro.moonlightmoist.shopapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MoonlightMoistShopApiServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
@@ -22,11 +22,21 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             @Param("now") LocalDateTime now
     );
 
-    // 누적 포인트
+    // 누적 포인트(사용안한것, 사용한것 다 포함) 조회 : 등급 업그레이드를 위한 쿼리
     @Query("SELECT COALESCE(SUM(p.pointValue), 0) FROM PointHistory p " +
             "WHERE p.user.id = :userId " +
             "AND p.pointStatus = 'EARNED'"
     )
     Long findCumulativePoints(@Param("userId") Long userId);
 
+    // 만료 대상 조회 : pointStatus 가 'EARNED' 이지만 만료기간이 지난 포인트히스토리 조회
+    @Query("SELECT p FROM PointHistory p " +
+            "WHERE p.pointStatus = 'EARNED' " +
+            "AND p.expiredAt <= :now " +
+            "AND p.deleted = false"
+    )
+    List<PointHistory> findExpiredPoints(@Param("now") LocalDateTime now);
+
+    // 포인트 만료 처리
+//    int updatePointStatusToExpired(@Param())
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/scheduler/PointExpireScheduler.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/scheduler/PointExpireScheduler.java
@@ -1,0 +1,43 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.scheduler;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.service.PointExpireService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointExpireScheduler {
+
+    private final PointExpireService pointExpireService;
+
+    // cron 표현식 04시 00분 00초
+    @Scheduled(cron = "0 0 4 * * *")
+    public void expirePointsDaily() {
+        log.info("포인트 만료 처리 스케줄러 시작");
+
+        try {
+            int cnt = pointExpireService.expirePoints();
+            log.info("포인트 만료 처리 {} 개 완료", cnt);
+        } catch (Exception e) {
+            log.error("포인트 만료 처리 중 오류 발생", e);
+        }
+        log.info("포인트 만료 처리 스케줄러 종료");
+    }
+
+    // 개발 중 테스트용 (1분마다 실행)
+//     @Scheduled(cron = "0 */1 * * * *")
+//     public void expirePointsForTest() {
+//         log.info("포인트 만료 처리 스케줄러 시작");
+//
+//         try {
+//             int cnt = pointExpireService.expirePoints();
+//             log.info("포인트 만료 처리 {} 개 완료", cnt);
+//         } catch (Exception e) {
+//             log.error("포인트 만료 처리 중 오류 발생", e);
+//         }
+//         log.info("포인트 만료 처리 스케줄러 종료");
+//     }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireService.java
@@ -1,0 +1,10 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.service;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
+
+import java.util.List;
+
+public interface PointExpireService {
+    List<PointHistory> getExpiredPoints();
+    int expirePoints();
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireServiceImpl.java
@@ -1,0 +1,40 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.service;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointStatus;
+import kr.kro.moonlightmoist.shopapi.pointHistory.repository.PointHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PointExpireServiceImpl implements PointExpireService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+
+    @Override
+    public List<PointHistory> getExpiredPoints() {
+        List<PointHistory> expiredPoints = pointHistoryRepository.findExpiredPoints(LocalDateTime.now());
+
+        return expiredPoints;
+    }
+
+    @Override
+    @Transactional
+    public int expirePoints() {
+        List<PointHistory> expiredPoints = pointHistoryRepository.findExpiredPoints(LocalDateTime.now());
+        if(expiredPoints.isEmpty()) {
+            log.info("만료 처리할 포인트가 없습니다.");
+        }
+        expiredPoints.forEach(ph -> ph.setPointStatus(PointStatus.EXPIRED));
+
+        return expiredPoints.size();
+    }
+
+}


### PR DESCRIPTION
- 매일 새벽 4시 스프링 스케줄러가 동작 하도록 함
- 아직 테스트 안함
- 메인 ServerApplication 에 @EnableScheduling 어노테이션 붙임
- PointHistoryRepository 에 만료 대상 포인트히스토리 조회 쿼리메서드 작성
- PointExpireServiceImpl 에서 만료 대상 포인트 조회 및 만료처리 로직 작성
- PointExpireScheduler 가 PointExpireService 를 이용해 매일 새벽4시 동작하도록 함