### PR TITLE
포인트 자동 만료 스케줄러 수정 및 테스트

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.pointHistory.repository;
 
 import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -37,6 +38,12 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     )
     List<PointHistory> findExpiredPoints(@Param("now") LocalDateTime now);
 
-    // 포인트 만료 처리
-//    int updatePointStatusToExpired(@Param())
+    // 만료기간 지난 포인트 일괄 만료 처리 (업데이트 쿼리 1개 : 벌크 업데이트)
+    @Modifying
+    @Query("UPDATE PointHistory p " +
+            "SET p.pointStatus = 'EXPIRED' " +
+            "WHERE p.pointStatus = 'EARNED' " +
+            "AND p.expiredAt < :now " +
+            "AND p.deleted = false")
+    int updatePointStatusToExpired(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointExpireServiceImpl.java
@@ -28,13 +28,11 @@ public class PointExpireServiceImpl implements PointExpireService {
     @Override
     @Transactional
     public int expirePoints() {
-        List<PointHistory> expiredPoints = pointHistoryRepository.findExpiredPoints(LocalDateTime.now());
-        if(expiredPoints.isEmpty()) {
+        int cnt = pointHistoryRepository.updatePointStatusToExpired(LocalDateTime.now());
+        if (cnt == 0) {
             log.info("만료 처리할 포인트가 없습니다.");
         }
-        expiredPoints.forEach(ph -> ph.setPointStatus(PointStatus.EXPIRED));
-
-        return expiredPoints.size();
+        return cnt;
     }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -363,6 +363,7 @@ INSERT INTO point_histories
 (user_id, point_status, point_value, remaining_point, expired_at, is_deleted, created_at, updated_at) VALUES
 (1, 'EARNED', 100, 100, '2026-12-01 00:00:00', FALSE, '2025-12-01 00:00:00', '2025-12-01 00:00:00'),
 (1, 'EARNED', 100, 100, '2026-12-01 00:05:00', FALSE, '2025-12-01 00:05:00', '2025-12-01 00:05:00'),
+(1, 'EARNED', 1000,1000, '2025-12-10 09:30:00', FALSE, NOW(), NOW()),
 (1, 'EXPIRED', 100, 100, '2024-12-01 00:05:00', FALSE, '2023-12-01 00:05:00', '2024-12-01 00:05:00');
 
 


### PR DESCRIPTION
- 기존의 자동 만료 로직은 jpa 의 더티체킹 기능을 이용하여 쿼리가 나가도록 했는데 이렇게 하면 N+1 문제가 발생한다. 따라서 벌크 업데이트를 하는 쿼리메서드를 구현해놓고 만료 처리할 수 있도록 함 이렇게 하면 하나의 쿼리로 일관 만료 처리 가능
- data.sql 에 테스트를 위한 데이터 삽입