### PR TITLE
재입고시 자동알람 발송 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/MoonlightMoistShopApiServerApplication.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/MoonlightMoistShopApiServerApplication.java
@@ -2,10 +2,12 @@ package kr.kro.moonlightmoist.shopapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class MoonlightMoistShopApiServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/common/config/CoolSmsConfig.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/common/config/CoolSmsConfig.java
@@ -2,7 +2,9 @@ package kr.kro.moonlightmoist.shopapi.common.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -15,4 +17,10 @@ public class CoolSmsConfig {
     private String apiSecret;
     private String sender;
     private boolean enabled;
+
+    @Bean
+    public DefaultMessageService defaultMessageService() {
+        return new DefaultMessageService(this.apiKey, this.apiSecret, "https://api.coolsms.co.kr");
+    }
+
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/notification/service/NotificationService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/notification/service/NotificationService.java
@@ -1,0 +1,73 @@
+package kr.kro.moonlightmoist.shopapi.notification.service;
+
+import kr.kro.moonlightmoist.shopapi.common.config.CoolSmsConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.message.exception.NurigoEmptyResponseException;
+import net.nurigo.sdk.message.exception.NurigoMessageNotReceivedException;
+import net.nurigo.sdk.message.exception.NurigoUnknownException;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.response.MultipleDetailMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final DefaultMessageService messageService;
+    private final CoolSmsConfig coolSmsConfig;
+
+    public void sendSmsMessage(String toNumber, String content) {
+        try {
+            Message message = new Message();
+            message.setFrom(coolSmsConfig.getSender());
+            message.setTo(toNumber);
+            message.setText(content);
+
+            MultipleDetailMessageSentResponse result = messageService.send(message);
+
+            log.info("발송 요청 후 응답 : {}", result);
+
+        } catch (NurigoMessageNotReceivedException e) {
+            log.info("수신자에게 발송 실패 : {}", e.getFailedMessageList());
+            throw new RuntimeException(e);
+        } catch (NurigoEmptyResponseException e) {
+            log.info("CoolSms 로부터 응답 없음 : {}", e.getMessage());
+            throw new RuntimeException(e);
+        } catch (NurigoUnknownException e) {
+            log.info("메시지 발송 요청 중 예기치 않은 오류 발생 : {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void sendBatchSmsMessage(List<String> toNumbers, String content) {
+        List<Message> messages = new ArrayList<>();
+
+        for (String number : toNumbers) {
+            Message message = new Message();
+            message.setFrom(coolSmsConfig.getSender());
+            message.setTo(number);
+            message.setText(content);
+
+            messages.add(message);
+        }
+
+        try {
+            messageService.send(messages);
+        } catch (NurigoMessageNotReceivedException e) {
+            log.info("일부 수신자에게 발송 실패 : {}", e.getFailedMessageList());
+            throw new RuntimeException(e);
+        } catch (NurigoEmptyResponseException e) {
+            log.info("CoolSms 로부터 응답 없음 : {}", e.getMessage());
+            throw new RuntimeException(e);
+        } catch (NurigoUnknownException e) {
+            log.info("메시지 발송 요청 중 예기치 않은 오류 발생 : {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductOptionController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/controller/ProductOptionController.java
@@ -1,0 +1,39 @@
+package kr.kro.moonlightmoist.shopapi.product.controller;
+
+import kr.kro.moonlightmoist.shopapi.product.dto.RestockOptionReq;
+import kr.kro.moonlightmoist.shopapi.product.service.ProductOptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/product_options")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*",
+        methods = {RequestMethod.GET,
+                RequestMethod.POST,
+                RequestMethod.PUT,
+                RequestMethod.PATCH,
+                RequestMethod.DELETE,
+                RequestMethod.OPTIONS})
+@RequiredArgsConstructor
+public class ProductOptionController {
+
+    private final ProductOptionService productOptionService;
+
+    @PatchMapping("/restock")
+    public ResponseEntity<String> restockOption(@RequestBody List<RestockOptionReq> dto) {
+        if (dto == null || dto.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("요청 데이터가 없습니다. 최소 하나의 재고 정보가 필요합니다.");
+        }
+
+        productOptionService.restockOptions(dto);
+
+        return ResponseEntity.ok("ok");
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/RestockOptionReq.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/dto/RestockOptionReq.java
@@ -1,0 +1,14 @@
+package kr.kro.moonlightmoist.shopapi.product.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class RestockOptionReq {
+    private Long optionId;
+    private int newStock;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductOptionRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductOptionRepository.java
@@ -2,10 +2,14 @@ package kr.kro.moonlightmoist.shopapi.product.repository;
 
 import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
-
     Optional<ProductOption> findByOptionName(String name);
+
+    @Query("SELECT o FROM ProductOption o WHERE o.id IN :ids")
+    List<ProductOption> findByIds(List<Long> ids);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductOptionService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductOptionService.java
@@ -1,0 +1,9 @@
+package kr.kro.moonlightmoist.shopapi.product.service;
+
+import kr.kro.moonlightmoist.shopapi.product.dto.RestockOptionReq;
+
+import java.util.List;
+
+public interface ProductOptionService {
+    void restockOptions(List<RestockOptionReq> dto);
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductOptionServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductOptionServiceImpl.java
@@ -1,0 +1,49 @@
+package kr.kro.moonlightmoist.shopapi.product.service;
+
+import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
+import kr.kro.moonlightmoist.shopapi.product.dto.RestockOptionReq;
+import kr.kro.moonlightmoist.shopapi.product.repository.ProductOptionRepository;
+import kr.kro.moonlightmoist.shopapi.restockNoti.event.RestockEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProductOptionServiceImpl implements ProductOptionService{
+
+    private final ProductOptionRepository productOptionRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    @Transactional
+    public void restockOptions(List<RestockOptionReq> dto) {
+        List<Long> ids = dto.stream().map(o -> o.getOptionId()).toList();
+        List<ProductOption> options = productOptionRepository.findByIds(ids);
+
+        Map<Long, Integer> optionMap = dto.stream().collect(Collectors.toMap(
+                o -> o.getOptionId(),
+                o -> o.getNewStock()
+        ));
+
+        for (ProductOption option : options) {
+            int oldStock = option.getCurrentStock();
+            int newStock = optionMap.get(option.getId());
+
+            option.setCurrentStock(newStock);
+
+            if (oldStock ==0 && newStock >=1 ) {
+                //이벤트 발행
+                applicationEventPublisher.publishEvent(new RestockEvent(option.getId(), option.getOptionName()));
+            }
+        }
+    }
+
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/event/RestockEvent.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/event/RestockEvent.java
@@ -1,0 +1,11 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RestockEvent {
+    private final Long optionId;
+    private final String optionName;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/event/RestockEventListener.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/event/RestockEventListener.java
@@ -1,0 +1,73 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.event;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.kro.moonlightmoist.shopapi.notification.service.NotificationService;
+import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
+import kr.kro.moonlightmoist.shopapi.product.repository.ProductOptionRepository;
+import kr.kro.moonlightmoist.shopapi.restockNoti.domain.NotificationType;
+import kr.kro.moonlightmoist.shopapi.restockNoti.domain.RestockNotification;
+import kr.kro.moonlightmoist.shopapi.restockNoti.repository.RestockNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RestockEventListener {
+    private final ProductOptionRepository productOptionRepository;
+    private final RestockNotificationRepository restockNotificationRepository;
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void handleRestockEvent(RestockEvent event) {
+        try {
+            // 재입고 공지 테이블에서 찾기
+            List<RestockNotification> notis = restockNotificationRepository.findByOptionIdAndWaiting(event.getOptionId());
+            ProductOption option = productOptionRepository.findById(event.getOptionId())
+                    .orElseThrow(() -> new EntityNotFoundException());
+
+            for (RestockNotification noti : notis) {
+                processNotification(noti, option);
+            }
+
+        } catch (Exception e) {
+            log.error("재입고 알림 발송 실패 : optionId={}", event.getOptionId());
+        }
+    }
+
+    private void processNotification(RestockNotification noti, ProductOption option) {
+        // 메시지 생성 로직 및 발송 로직
+        String message = String.format(
+                "달빛나라 촉촉마을 상품 재입고 알림!\n" +
+                        "[%s]상품의 옵션 '%s' 이 재입고 되었습니다! ",
+                option.getProduct().getBasicInfo().getProductName(),
+                option.getOptionName()
+        );
+
+        CompletableFuture.runAsync(() -> {
+           try {
+               notificationService.sendSmsMessage(noti.getUser().getPhoneNumber(), message);
+
+               // 성공 로그 저장
+
+           } catch (Exception e) {
+               // 발송 실패시 로그 저장
+               log.info("발송 실패 : {}", e.getMessage());
+           }
+        }
+        // 사용자 정의 asyncExecutor
+//        , asyncExecutor
+        );
+
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/repository/RestockNotificationRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/repository/RestockNotificationRepository.java
@@ -2,10 +2,16 @@ package kr.kro.moonlightmoist.shopapi.restockNoti.repository;
 
 import kr.kro.moonlightmoist.shopapi.restockNoti.domain.RestockNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface RestockNotificationRepository extends JpaRepository<RestockNotification, Long> {
 
     List<RestockNotification> findByProductOptionId(Long productOptionId);
+    @Query("SELECT n FROM RestockNotification n " +
+            "WHERE n.productOption.id = :optionId " +
+            "AND n.notificationStatus = 'WAITING'")
+    List<RestockNotification> findByOptionIdAndWaiting(@Param("optionId") Long optionId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,13 @@ spring.servlet.multipart.max-file-size=10MB
 #file location
 com.green.blue.red.upload.path=upload
 
-#security log
+# ===== Spring Task Execution Thread Pool Config (Async Thread Pool) ======
+spring.task.execution.pool.core-size=5
+spring.task.execution.pool.max-size=20
+spring.task.execution.pool.queue-capacity=100
+
+
+# ==== security log ====
 #logging.level.org.springframework.security.web=trace
 
 # ===== AWS S3 =====

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -352,7 +352,7 @@ VALUES
 (1,'user1','$2a$10$6qw3yYsjV9MYb6FDQnwPOOtoKIgOm9my7xw4yWeuY4CaX/fA3LRFW','사용자1','01011111111','user1@test.com','1996-01-01','11111','서울시 강남구','101호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw1
 (2,'user2','$2a$10$IbDZlbdF40gBOiwzG1mdeuO5qYwtfnZhn2gZM/pv3qdaH9qfuHEo.','사용자2','01022222222','user2@test.com','1996-02-02','22222','서울시 강북구','102호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw2
 (3,'user3','$2a$10$S2oOm7Lu5R5LcYdtK8d2I.9kNXaF86rTUUPDTUeUgXHTpT9MJiR3S','사용자3','01033333333','user3@test.com','1996-03-03','33333','서울시 송파구','103호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw3
-(4,'user4','$2a$10$1x8TArF9Cnvm5gEDyTCax.uzWL7AKOTt86AJqcW5utqqLWIDrhwLa','사용자4','01044444444','user4@test.com','1996-04-04','44444','서울시 영등포구','104호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw4
+(4,'user4','$2a$10$1x8TArF9Cnvm5gEDyTCax.uzWL7AKOTt86AJqcW5utqqLWIDrhwLa','사용자4','01046624036','user4@test.com','1992-12-25','44444','서울시 영등포구','104호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw4
 (5,'user5','$2a$10$spuiucMhP0dXXkoczVqjEOP.K77uvjIq6Uq6JXZGQW8q47JuSB.3O','사용자5','01055555555','user5@test.com','1996-05-05','55555','서울시 마포구','105호',true,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- pw5
 (6,'user','$2a$10$jmrm8qUUoTnz/r2XW6hWeOZOtvO9SAUI2rnsFUcCkbNZTDqs6mSYG','유저','01012345677','user@naver.com','2025-12-08','12345','성남시 미금역','그린아카데미',false,true,false,NULL,'USER','BRONZE',NOW(),NOW()), -- a
 (7,'admin','$2a$10$zzjjAVRFjyLxdWpR4HPmbOCLmS2C8LeEAURv5lQtLgMPpVBe5sfZi','관리자','01012345678','admin@naver.com','2025-12-08','12345','성남시 미금역','그린아카데미',false,true,false,NULL,'ADMIN','VIP',NOW(),NOW()); -- a


### PR DESCRIPTION
- ProductOptionController : 재입고처리하기 위해 Patch 요청을 받는 컨트롤러 작성
- ProductOptionService, ProductOptionServiceImpl : 재입고 로직을 처리하면서 기존재고가 0 에서 1이상으로 채워졌다면 RestockEvent 를 발행함
- ProductOptionRepository : 재입고처리 로직을 위한 쿼리메서드 findByIds생성
- RestockEvent : 재입고 이벤트 클래스 작성
- RestockEventListener :
  - RestockEvent 발생시 동작하는 이벤트 리스너 작성
  - 재입고 처리 트랜잭션과 별도의 트랜잭션에서 실행되도록 함
  - 메시지 발송 로직 구현
  - 발송한 메시지에 대한 로그를 테이블에 기록하는 기능은 아직 미구현
- RestockNotificationRepository : optionId 로 재입고공지요청을 찾는 쿼리메서드 findByProductOptionId 작성
- NotificationService :
  - 알림발송 서비스 클래스 작성
  - Sms 메시지 발송을 위한 메서드 2개 구현 (단일 메시지, 다량의 메시지 발송)  중 단일 메시지 발송 메서드만 사용 중 , 이것만 사용해도 됨
- MoonlightMostShopApiServerApplication 에 비동기 처리를 위한 @EnableAsync 어노테이션 달아놓음
- application.properties 에 비동기 쓰레드 풀 설정 추가
- data.sql 에 user4 의 폰 번호를 내 번호로 변경
- CoolSmsConfig 작성