### PR TITLE
주문 취소시 사용한 포인트 복구 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/controller/OrderController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/controller/OrderController.java
@@ -33,10 +33,11 @@ public class OrderController {
     @PostMapping("")
     public ResponseEntity<Long> registerOrder(@RequestBody OrderRequestDTO orderRequestDTO, @RequestParam Long userId) {
         log.info("registerOrder 메서드 실행 dto :{}", orderRequestDTO);
+        Long orderId = orderService.createOrder(orderRequestDTO, userId);
         // 사용한 포인트 차감
-        pointHistoryService.usePoint(userId, orderRequestDTO.getUsedPoints());
+        pointHistoryService.usePoint(userId, orderId, orderRequestDTO.getUsedPoints());
 
-        return ResponseEntity.ok(orderService.createOrder(orderRequestDTO, userId));
+        return ResponseEntity.ok(orderId);
     }
 
     @GetMapping("")

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/controller/PointHistoryController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/controller/PointHistoryController.java
@@ -32,14 +32,14 @@ public class PointHistoryController {
 
     @PostMapping("/earn")
     public ResponseEntity<String> earnPoint(@RequestBody PointEarnReq dto) {
-        pointHistoryService.earnPoint(dto.getUserId(), dto.getPointValue());
+//        pointHistoryService.earnPoint(dto.getUserId(), dto.getPointValue());
 
         return ResponseEntity.ok("ok");
     }
 
     @PostMapping("/use")
     public ResponseEntity<String> usePoint(@RequestBody PointUseReq dto) {
-        pointHistoryService.usePoint(dto.getUserId(), dto.getAmountToUse());
+//        pointHistoryService.usePoint(dto.getUserId(), dto.getAmountToUse());
 
         return ResponseEntity.ok("ok");
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointHistory.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointHistory.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.pointHistory.domain;
 
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import kr.kro.moonlightmoist.shopapi.order.domain.Order;
 import kr.kro.moonlightmoist.shopapi.user.domain.User;
 import lombok.*;
 
@@ -25,6 +26,10 @@ public class PointHistory extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
+
     @Enumerated(EnumType.STRING)
     private PointStatus pointStatus;
 
@@ -36,4 +41,7 @@ public class PointHistory extends BaseTimeEntity {
     @Builder.Default
     private boolean deleted = false;
 
+    public void plusRemainingPoint(int value) {
+        this.remainingPoint += value;
+    }
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointStatus.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointStatus.java
@@ -1,5 +1,5 @@
 package kr.kro.moonlightmoist.shopapi.pointHistory.domain;
 
 public enum PointStatus {
-    EARNED,USED,EXPIRED
+    EARNED,USED,EXPIRED,CANCELLED
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointUsageDetail.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/domain/PointUsageDetail.java
@@ -1,0 +1,30 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.domain;
+
+import jakarta.persistence.*;
+import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Table(name = "point_usage_details")
+public class PointUsageDetail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "used_point_history_id")
+    private PointHistory usedPointHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "earned_point_history_id")
+    private PointHistory earnedPointHistory;
+
+    private int usedAmount;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointHistoryRepository.java
@@ -46,4 +46,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             "AND p.expiredAt < :now " +
             "AND p.deleted = false")
     int updatePointStatusToExpired(@Param("now") LocalDateTime now);
+
+    // 주문 id 로 히스토리 찾기
+    List<PointHistory> findByOrderId(Long orderId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointUsageDetailRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/repository/PointUsageDetailRepository.java
@@ -1,0 +1,15 @@
+package kr.kro.moonlightmoist.shopapi.pointHistory.repository;
+
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointUsageDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PointUsageDetailRepository extends JpaRepository<PointUsageDetail, Long> {
+    @Query("SELECT d FROM PointUsageDetail d " +
+            "JOIN FETCH d.earnedPointHistory " +
+            "WHERE d.usedPointHistory.id = :usedHistoryId")
+    List<PointUsageDetail> findByUsedPointHistoryIdWithEarned(@Param("usedHistoryId") Long usedHistoryId);
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryService.java
@@ -2,6 +2,7 @@ package kr.kro.moonlightmoist.shopapi.pointHistory.service;
 
 public interface PointHistoryService {
     int getActivePoint(Long userId);
-    void earnPoint(Long userId, int pointValue);
-    void usePoint(Long userId, int amountToUse);
+    void earnPoint(Long userId, Long orderId, int pointValue);
+    void usePoint(Long userId, Long orderId, int amountToUse);
+    void rollbackPoint(Long orderId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/pointHistory/service/PointHistoryServiceImpl.java
@@ -1,8 +1,13 @@
 package kr.kro.moonlightmoist.shopapi.pointHistory.service;
 
+import jakarta.persistence.EntityNotFoundException;
+import kr.kro.moonlightmoist.shopapi.order.domain.Order;
+import kr.kro.moonlightmoist.shopapi.order.repository.OrderRepository;
 import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointHistory;
 import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointStatus;
+import kr.kro.moonlightmoist.shopapi.pointHistory.domain.PointUsageDetail;
 import kr.kro.moonlightmoist.shopapi.pointHistory.repository.PointHistoryRepository;
+import kr.kro.moonlightmoist.shopapi.pointHistory.repository.PointUsageDetailRepository;
 import kr.kro.moonlightmoist.shopapi.user.domain.User;
 import kr.kro.moonlightmoist.shopapi.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +15,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +25,8 @@ public class PointHistoryServiceImpl implements PointHistoryService{
 
     private final UserRepository userRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final PointUsageDetailRepository pointUsageDetailRepository;
+    private final OrderRepository orderRepository;
 
 
     @Override
@@ -30,11 +39,14 @@ public class PointHistoryServiceImpl implements PointHistoryService{
     }
 
     @Override
-    public void earnPoint(Long userId, int pointValue) {
-        User user = userRepository.findById(userId).get();
+    @Transactional
+    public void earnPoint(Long userId, Long orderId, int pointValue) {
+        User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        Order order = orderRepository.findById(orderId).orElseThrow(EntityNotFoundException::new);
 
         PointHistory pointHistory = PointHistory.builder()
                 .user(user)
+                .order(order)
                 .pointStatus(PointStatus.EARNED)
                 .pointValue(pointValue)
                 .remainingPoint(pointValue)
@@ -45,9 +57,10 @@ public class PointHistoryServiceImpl implements PointHistoryService{
 
     @Override
     @Transactional
-    public void usePoint(Long userId, int amountToUse) {
+    public void usePoint(Long userId, Long orderId, int amountToUse) {
         // 유효기간 얼마 안남은 순서로 가져옴
         List<PointHistory> allActivePoints = pointHistoryRepository.findAllActivePoints(userId, LocalDateTime.now());
+        Order order = orderRepository.findById(orderId).orElseThrow(EntityNotFoundException::new);
 
         int totalBalance = allActivePoints.stream().mapToInt(p -> p.getRemainingPoint()).sum();
         if (totalBalance < amountToUse) {
@@ -55,30 +68,86 @@ public class PointHistoryServiceImpl implements PointHistoryService{
         }
 
         int remainingAmountToUse = amountToUse;
+        List<PointUsageDetail> usageDetails = new ArrayList<>();
 
-        for (PointHistory history : allActivePoints) {
+        for (PointHistory history : allActivePoints ) {
+            if (remainingAmountToUse == 0) {
+                break;
+            }
+
             int availablePoint = history.getRemainingPoint();
+            int usedPointInHistory = 0;
 
             if (availablePoint >= remainingAmountToUse) {
+                usedPointInHistory = remainingAmountToUse;
                 // 이 내역 하나로 충분할 때
                 history.setRemainingPoint(availablePoint - remainingAmountToUse);
                 remainingAmountToUse = 0;
-                break;
             } else {
+                usedPointInHistory = availablePoint;
                 // 이 내역을 다 써도 부족할 때 (부분 차감)
                 history.setRemainingPoint(0);
                 remainingAmountToUse -= availablePoint;
+            }
+
+            if (usedPointInHistory > 0) {
+                usageDetails.add(PointUsageDetail.builder()
+                                .earnedPointHistory(history)
+                                .usedAmount(usedPointInHistory)
+                        .build()
+                );
             }
         }
 
         User user = userRepository.findById(userId).get();
         // 사용 history 를 남겨야함
-        PointHistory usageHistory = PointHistory.builder()
+        PointHistory usedHistory = PointHistory.builder()
                 .user(user)
+                .order(order)
                 .pointStatus(PointStatus.USED)
                 .pointValue(-amountToUse)
                 .remainingPoint(0)
                 .build();
-        pointHistoryRepository.save(usageHistory);
+        pointHistoryRepository.save(usedHistory);
+
+        // PointUsageDetail에 usedPointHistory 기록 후 저장
+        usageDetails.forEach(detail -> {
+            detail.setUsedPointHistory(usedHistory);
+            pointUsageDetailRepository.save(detail);
+        });
+    }
+
+    @Override
+    @Transactional
+    public void rollbackPoint(Long orderId) {
+
+        PointHistory usedHistory = pointHistoryRepository.findByOrderId(orderId)
+                .stream().filter(h -> h.getPointStatus().equals(PointStatus.USED))
+                .findFirst().orElseThrow(EntityNotFoundException::new);
+
+        List<PointUsageDetail> pointUsages = pointUsageDetailRepository.findByUsedPointHistoryIdWithEarned(usedHistory.getId());
+
+        List<PointHistory> earnedHistories = pointUsages.stream()
+                .map(u -> u.getEarnedPointHistory()).toList();
+
+        // 포인트 복구
+        for (PointUsageDetail pointUsage : pointUsages) {
+            PointHistory earnedHistory = pointUsage.getEarnedPointHistory();
+
+            earnedHistory.plusRemainingPoint(pointUsage.getUsedAmount());
+        }
+
+        Order order = orderRepository.findById(orderId).orElseThrow(EntityNotFoundException::new);
+        User user = order.getUser();
+
+        // CANCELLED 포인트 히스토리 생성
+        PointHistory cancelledHistory = PointHistory.builder()
+                .user(user)
+                .order(order)
+                .pointStatus(PointStatus.CANCELLED)
+                .pointValue(order.getUsedPoints())
+                .build();
+
+        pointHistoryRepository.save(cancelledHistory);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -362,13 +362,6 @@ INSERT INTO restock_notifications (id, user_id, product_option_id, notification_
 (1, 4, 5, 'SMS' ,'WAITING', NULL, FALSE, NOW(), NOW());
 
 
--- 포인트 히스토리
-INSERT INTO point_histories
-(user_id, point_status, point_value, remaining_point, expired_at, is_deleted, created_at, updated_at) VALUES
-(1, 'EARNED', 100, 100, '2026-12-01 00:00:00', FALSE, '2025-12-01 00:00:00', '2025-12-01 00:00:00'),
-(1, 'EARNED', 100, 100, '2026-12-01 00:05:00', FALSE, '2025-12-01 00:05:00', '2025-12-01 00:05:00'),
-(1, 'EARNED', 1000,1000, '2025-12-10 09:30:00', FALSE, NOW(), NOW()),
-(1, 'EXPIRED', 100, 100, '2024-12-01 00:05:00', FALSE, '2023-12-01 00:05:00', '2024-12-01 00:05:00');
 
 
 -- 발급받은 유저 쿠폰
@@ -433,7 +426,7 @@ discount_amount, used_points, earned_points, final_amount, receiver_name, receiv
 detailed_address, delivery_request, is_deleted, created_at, updated_at)
 VALUES
 -- 1. 1개월 내 주문 (2025-11-05 생성)
-(1, 1, '20251105-A1B2C3', 'KAKAO', '2025-11-07', 55000, 3000, 5000, 0, 0, 53000, '홍길동',
+(1, 1, '20251105-A1B2C3', 'KAKAO', '2025-11-07', 55000, 3000, 5000, 100, 0, 53000, '홍길동',
 '010-1234-5678', '01234', '서울특별시 강남구 테헤란로 123', '삼성타워빌딩 10층', '문 앞에 놓아주세요',
 false, '2025-11-05 10:30:00', '2025-11-05 10:30:00'),
 -- 2. 3개월 내 주문 (2025-09-15 생성)
@@ -892,6 +885,23 @@ VALUES
 (18, 6, 5, 5, '리뷰18', 1, true, false, '2024-12-25 18:00:00', '2025-12-25 18:00:00'),
 (19, 6, 2, 5, '리뷰19', 5, true, false, '2024-09-05 18:00:00', '2025-09-05 18:00:00'),
 (20, 6, 3, 5, '리뷰20', 4, true, false, '2024-09-05 18:00:00', '2025-09-05 18:00:00');
+
+
+-- 포인트 히스토리
+INSERT INTO point_histories
+(user_id, order_id, point_status, point_value, remaining_point, expired_at, is_deleted, created_at, updated_at) VALUES
+(1, NULL, 'EARNED', 200, 200, '2026-12-01 00:00:00', FALSE, '2025-12-01 00:00:00', '2025-12-01 00:00:00'),
+(1, NULL, 'EARNED', 100, 100, '2026-12-01 00:05:00', FALSE, '2025-12-01 00:05:00', '2025-12-01 00:05:00'),
+(4, 1, 'USED', 100, NULL, NULL, FALSE, '2025-12-01 00:05:00', '2025-12-01 00:05:00'),
+(1, NULL, 'EARNED', 1000,1000, '2025-12-10 09:30:00', FALSE, NOW(), NOW()),
+(1, NULL, 'EXPIRED', 100, 100, '2024-12-01 00:05:00', FALSE, '2023-12-01 00:05:00', '2024-12-01 00:05:00');
+
+-- 포인트 사용 내역
+INSERT INTO point_usage_details
+(used_point_history_id, earned_point_history_id, used_amount, created_at, updated_at) VALUES
+(3, 1, 100, '2025-12-01 00:05:00', '2025-12-01 00:05:00');
+
+
 
 -- 민석 데이터 크롤링
 -- ========================================


### PR DESCRIPTION
- PointUsageDetail 엔티티 생성 :
  - 포인트 사용 내역을 기록하기 위한 엔티티이다.
  - 이 기록이 있어야 차감된 PointHistory 를 제대로 찾아 차감된 값을 되돌릴 수 있다.

- PointHistory 엔티티에 Order 필드 추가
  - 어떤 주문에 대한 기록인지 알아야 포인트를 되돌릴 수 있다.

- PointHistoryServiceImpl 에서  earnPoint, usePoint 수정  rollbackPoint 생성
  - earnPoint() : orderId 를 받아 Order 를 들고 있을 수 있도록 함
  - usePoint() : 포인트 사용시 PointUsageDetail 에 기록이 남을 수 있도록 로직 추가
  - rollbackPoint() : orderId 를 받아 PointUsageDetail 기록을 추적하여 사용된 포인트가 복구되도록 로직을 구성함