### PR TITLE
재입고 알림 신청 기능 구현

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/controller/RestockNotificationController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/controller/RestockNotificationController.java
@@ -1,0 +1,31 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.controller;
+
+import kr.kro.moonlightmoist.shopapi.restockNoti.dto.RestockNotiReq;
+import kr.kro.moonlightmoist.shopapi.restockNoti.repository.RestockNotificationRepository;
+import kr.kro.moonlightmoist.shopapi.restockNoti.service.RestockNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/restock-notification")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*",
+        methods = {RequestMethod.GET,
+                RequestMethod.POST,
+                RequestMethod.PUT,
+                RequestMethod.DELETE,
+                RequestMethod.OPTIONS})
+@RequiredArgsConstructor
+public class RestockNotificationController {
+
+    private final RestockNotificationService restockNotificationService;
+
+    @PostMapping("")
+    public ResponseEntity<Long> applyRestockAlarm(@RequestBody RestockNotiReq req) {
+        log.info("userId : {}, optionId : {}", req.getUserId(), req.getOptionId());
+        Long id = restockNotificationService.applyRestockNotification(req.getUserId(), req.getOptionId());
+        return ResponseEntity.ok(id);
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/domain/RestockNotification.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/domain/RestockNotification.java
@@ -15,7 +15,14 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @ToString
 @Entity
-@Table(name = "restock_notifications")
+@Table(name = "restock_notifications",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_user_product_option",
+                    columnNames = {"user_id", "product_option_id"}
+            )
+        }
+)
 public class RestockNotification extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/dto/RestockNotiReq.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/dto/RestockNotiReq.java
@@ -1,0 +1,14 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class RestockNotiReq {
+    private Long userId;
+    private Long optionId;
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/repository/RestockNotificationRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/repository/RestockNotificationRepository.java
@@ -6,12 +6,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RestockNotificationRepository extends JpaRepository<RestockNotification, Long> {
 
     List<RestockNotification> findByProductOptionId(Long productOptionId);
+
     @Query("SELECT n FROM RestockNotification n " +
             "WHERE n.productOption.id = :optionId " +
             "AND n.notificationStatus = 'WAITING'")
     List<RestockNotification> findByOptionIdAndWaiting(@Param("optionId") Long optionId);
+
+    Optional<RestockNotification> findByUserIdAndProductOptionId(Long userId, Long optionId);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/service/RestockNotificationService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/service/RestockNotificationService.java
@@ -1,0 +1,5 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.service;
+
+public interface RestockNotificationService {
+    Long applyRestockNotification(Long userId, Long optionId);
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/service/RestockNotificationServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/restockNoti/service/RestockNotificationServiceImpl.java
@@ -1,0 +1,47 @@
+package kr.kro.moonlightmoist.shopapi.restockNoti.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
+import kr.kro.moonlightmoist.shopapi.product.repository.ProductOptionRepository;
+import kr.kro.moonlightmoist.shopapi.restockNoti.domain.NotificationStatus;
+import kr.kro.moonlightmoist.shopapi.restockNoti.domain.NotificationType;
+import kr.kro.moonlightmoist.shopapi.restockNoti.domain.RestockNotification;
+import kr.kro.moonlightmoist.shopapi.restockNoti.repository.RestockNotificationRepository;
+import kr.kro.moonlightmoist.shopapi.user.domain.User;
+import kr.kro.moonlightmoist.shopapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestockNotificationServiceImpl implements RestockNotificationService{
+
+    private final RestockNotificationRepository restockNotificationRepository;
+    private final UserRepository userRepository;
+    private final ProductOptionRepository productOptionRepository;
+
+    @Override
+    public Long applyRestockNotification(Long userId, Long optionId) {
+
+        User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        ProductOption option = productOptionRepository.findById(optionId).orElseThrow(EntityNotFoundException::new);
+
+        if (restockNotificationRepository.findByUserIdAndProductOptionId(userId, optionId).isPresent()) {
+            return Long.valueOf(0);
+        }
+
+
+        RestockNotification restockNotification = RestockNotification.builder()
+                .user(user)
+                .productOption(option)
+                .notificationType(NotificationType.SMS)
+                .notificationStatus(NotificationStatus.WAITING)
+                .build();
+
+        return restockNotificationRepository.save(restockNotification).getId();
+    }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -359,7 +359,7 @@ VALUES
 
 
 INSERT INTO restock_notifications (id, user_id, product_option_id, notification_type, notification_status, notified_at, is_deleted, created_at, updated_at) VALUES
-(1, 4, 5, 'SMS' ,'WAITING', NULL, FALSE, NOW(), NOW());
+(1, 4, 5, 'SMS' ,'WAITING', NULL, FALSE, '2025-11-01 00:00:00', '2025-11-01 00:00:00');
 
 
 


### PR DESCRIPTION
- 로그인한 유저가 재입고 알림 신청 시 restock_notifications 테이블에 데이터 추가 기능 구현
  - user_id 와 option_id 의 조합은 유니크 해야 한다. 유니크제약조건 추가
  - user_id 와 option_id 의 조합이 같은 경우가 이미 테이블에 있을 경우 서비스레이어에서 0 을 리턴하도록 함
  - 추후 커스텀 예외를 만들고 예외 핸들러를 통해 응답처리를 해보자