### PR TITLE
[백엔드] 조건에 따라 주문 조회하는 메서드 수정

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/controller/OrderController.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/controller/OrderController.java
@@ -11,6 +11,7 @@ import kr.kro.moonlightmoist.shopapi.review.dto.PageRequestDTO;
 import kr.kro.moonlightmoist.shopapi.review.dto.PageResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -70,10 +71,18 @@ public class OrderController {
     }
 
     @PostMapping("/search")
-    public ResponseEntity<List<OrderResBySearch>> searchOrdersByCondition(@RequestBody OrderSearchCondition condition) {
-        List<OrderResBySearch> orderResBySearches = orderService.searchOrdersByCondition(condition);
+    public ResponseEntity<PageResponseDTO<OrderResBySearch>> searchOrdersByCondition(
+            @RequestBody OrderSearchCondition condition,
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
+                .page(page)
+                .size(size)
+                .build();
 
-        return ResponseEntity.ok(orderResBySearches);
+        return ResponseEntity.ok(orderService.searchOrdersByCondition(condition, sort, pageRequestDTO));
     }
 
     @PutMapping("/confirm/{orderId}")

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/Order.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/Order.java
@@ -144,11 +144,11 @@ public class Order extends BaseTimeEntity {
         OrderResBySearch orderRes = OrderResBySearch.builder()
                 .id(this.getId())
                 .orderDate(this.getCreatedAt().toLocalDate())
-                .ordererName(this.user.getName())
-                .receiverName(this.getReceiverName())
                 .orderNumber(this.getOrderNumber())
-                .paymentMethod(this.getPaymentMethod())
                 .orderProducts(this.getOrderProducts().stream().map(op -> op.toDtoForOrderProductResBySearch()).toList())
+                .receiverName(this.getReceiverName())
+                .ordererName(this.user.getName())
+                .paymentMethod(this.getPaymentMethod())
                 .build();
         return orderRes;
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/OrderProduct.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/OrderProduct.java
@@ -3,6 +3,7 @@ package kr.kro.moonlightmoist.shopapi.order.domain;
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import kr.kro.moonlightmoist.shopapi.order.dto.OrderProductResBySearch;
+import kr.kro.moonlightmoist.shopapi.product.domain.ImageType;
 import kr.kro.moonlightmoist.shopapi.product.domain.Product;
 import kr.kro.moonlightmoist.shopapi.product.domain.ProductOption;
 import lombok.*;
@@ -52,9 +53,10 @@ public class OrderProduct extends BaseTimeEntity {
                 .id(this.getId())
                 .productName(this.getProductOption().getProduct().getBasicInfo().getProductName())
                 .productOptionName(this.getProductOption().getOptionName())
-                .orderProductStatus(this.getOrderProductStatus())
                 .quantity(this.getQuantity())
+                .imageUrl(this.getProductOption().getProduct().getMainImages().stream().filter(i->i.getImageType()== ImageType.THUMBNAIL).findFirst().get().getImageUrl())
                 .totalAmount(this.getPurchasedPrice()*this.getQuantity())
+                .orderProductStatus(this.getOrderProductStatus())
                 .build();
         return orderProductRes;
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResBySearch.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResBySearch.java
@@ -10,9 +10,16 @@ import lombok.*;
 @AllArgsConstructor
 public class OrderProductResBySearch {
     private Long id;
+    // 상품 이름
     private String productName;
+    // 상품 옵션 이름
     private String productOptionName;
+    // 상품 갯수
     private int quantity;
+    // 상품 썸네일 이미지 url
+    private String imageUrl;
+    // 상품 총 금액(상품 갯수 x 상품 1개의 가격)
     private int totalAmount;
+    // 상품 주문 상태(주문 접수, 결제 완료, 배송준비중, 배송중, 배송완료, 구매확정)
     private OrderProductStatus orderProductStatus;
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderSearchCondition.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderSearchCondition.java
@@ -12,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderSearchCondition {
+    private Long userId;
     private String orderNumber;
     private String ordererName;
     private String productName;

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepository.java
@@ -2,9 +2,11 @@ package kr.kro.moonlightmoist.shopapi.order.repository;
 
 import kr.kro.moonlightmoist.shopapi.order.domain.Order;
 import kr.kro.moonlightmoist.shopapi.order.dto.OrderSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface OrderCustomRepository {
-    List<Order> search(OrderSearchCondition condition);
+    Page<Order> search(OrderSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepositoryImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.kro.moonlightmoist.shopapi.order.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import kr.kro.moonlightmoist.shopapi.order.domain.Order;
@@ -11,6 +12,9 @@ import kr.kro.moonlightmoist.shopapi.order.dto.OrderSearchCondition;
 import kr.kro.moonlightmoist.shopapi.product.domain.QBasicInfo;
 import kr.kro.moonlightmoist.shopapi.product.domain.QProduct;
 import kr.kro.moonlightmoist.shopapi.product.domain.QProductOption;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -25,19 +29,23 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository{
     }
 
     @Override
-    public List<Order> search(OrderSearchCondition condition) {
+    public Page<Order> search(OrderSearchCondition condition, Pageable pageable) {
         QOrder order = QOrder.order;
         QOrderProduct orderProduct = QOrderProduct.orderProduct;
         QProductOption productOption = QProductOption.productOption;
         QProduct product = QProduct.product;
 
-        List<Order> orderList = queryFactory
+        // 1. Contents Query (데이터 쿼리) 생성
+        // JPQLQuery 객체로 쿼리 본체를 구성
+        JPQLQuery<Order> query = queryFactory
                 .selectFrom(order)
-                .join(order.orderProducts,orderProduct)
-                .join(orderProduct.productOption, productOption)
-                .join(productOption.product, product)
+                // fetchJoin()을 사용하여 N+1 문제 방지 (필요 시 추가)
+                .join(order.orderProducts,orderProduct).fetchJoin()
+                .join(orderProduct.productOption, productOption).fetchJoin()
+                .join(productOption.product, product).fetchJoin()
                 .where(
                         order.deleted.isFalse(),
+                        userIdFilter(condition.getUserId()),
                         orderNumberFilter(condition.getOrderNumber()),
                         ordererNameFilter(condition.getOrdererName()),
                         productNameFilter(condition.getProductName(), product),
@@ -49,14 +57,50 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository{
                         //deliveryFilter(condition.getSelectedDelivery()),
                         paymentFilter(condition.getSelectedPayment())
                 )
-                .orderBy(order.createdAt.desc())
+                .orderBy(order.createdAt.desc());
+
+        // 2. 페이징 적용 (OFFSET, LIMIT)
+        // Spring Data JPA의 Pageable 정보로 DB 쿼리에 페이징을 적용합니다.
+        List<Order> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
-        System.out.println("result= " + orderList);
-        System.out.println("result.size() = " + orderList.size());
+        // 3. Count Query (전체 개수 쿼리) 생성 및 실행
+        // Count 쿼리는 JOIN으로 인한 중복을 막기 위해 countDistinct()를 사용하고,
+        // SELECT 절을 제외한 WHERE 조건은 Contents Query와 동일하게 유지합니다.
+        Long total = queryFactory
+                .select(order.countDistinct()) // DISTINCT를 사용하여 정확한 주문 건수 카운트
+                .from(order)
+                .join(order.orderProducts, orderProduct)
+                .join(orderProduct.productOption, productOption)
+                .join(productOption.product, product)
+                .where(
+                        order.deleted.isFalse(),
+                        userIdFilter(condition.getUserId()),
+                        orderNumberFilter(condition.getOrderNumber()),
+                        ordererNameFilter(condition.getOrdererName()),
+                        productNameFilter(condition.getProductName(), product),
+                        dateFilter(
+                                condition.getStartDate() != null ? condition.getStartDate().atStartOfDay() : null,
+                                condition.getEndDate() != null ? condition.getEndDate().atTime(LocalTime.MAX) : null
+                        ),
+                        orderStatusFilter(condition.getSelectedOrderStatus()),
+                        paymentFilter(condition.getSelectedPayment())
+                )
+                .fetchOne();
 
-        return orderList;
+        // 4. PageImpl 객체로 반환
+        return new PageImpl<>(content, pageable, total);
     }
+
+    private BooleanExpression userIdFilter(Long userId) {
+        if(userId == null) return null;
+
+        QOrder order = QOrder.order;
+        return order.user.id.eq(userId);
+    }
+
 
     private BooleanExpression orderNumberFilter(String orderNumber) {
         if(orderNumber == null || orderNumber.trim().isEmpty()) {

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/service/OrderService.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/service/OrderService.java
@@ -3,6 +3,7 @@ package kr.kro.moonlightmoist.shopapi.order.service;
 import kr.kro.moonlightmoist.shopapi.order.dto.*;
 import kr.kro.moonlightmoist.shopapi.review.dto.PageRequestDTO;
 import kr.kro.moonlightmoist.shopapi.review.dto.PageResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,7 +17,7 @@ public interface OrderService {
     // 결제 검증이 끝나고 주문 상품 상태를 결제 완료로 변경
     void completeOrder(String merchantUid);
     void deleteOneOrder(Long orderId);
-    List<OrderResBySearch> searchOrdersByCondition(OrderSearchCondition condition);
+    PageResponseDTO<OrderResBySearch> searchOrdersByCondition(OrderSearchCondition condition, String sort, PageRequestDTO pageRequestDTO);
     void comfirmOrder(Long orderId);
 
 }


### PR DESCRIPTION
- 페이지네이션 적용하여 searchOrdersByCondition 메서드의 반환 타입을 PageResponseDTO로 변경, RequestParam으로 sort, page, size를 프론트로부터 전달받도록 함
- OrderCustomRepository의 search 메서드의 반환 타입을 List에서 Page 객체로 변경
- OrderCustomRepositoryImpl에서 search 메서드 코드 수정(데이터 쿼리 생성, 페이징 적용, 전체 개수 쿼리 생성, PageImpl 객체로 반환)
- OrderCustomRepositoryImpl에서 userIdFilter 메서드 추가
- OrderProductResBySearch 필드 추가(imageUrl), 주석 달아놓음, OrderProduct 객체의 메서드 toDtoForOrderProductResBySearch()에 imageUrl 필드 추가
- OrderSearchCondition(주문 검색 조건)에 userId 필드 추가