### PR TITLE
상품 목록 조회 정렬 기능 추가

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductRepository.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/repository/ProductRepository.java
@@ -18,4 +18,33 @@ public interface ProductRepository extends JpaRepository<Product, Long>
 
     // 3차 카테고리 id 리스트로 조회
     Page<Product> findByCategoryIdIn(List<Long> categoryIds, Pageable pageable);
+
+    // 가격정렬 : 최소가격부터
+    @Query(value = """
+            SELECT p.*
+            FROM products p
+            LEFT JOIN product_options o ON p.id = o.product_id
+            WHERE p.category_id IN :categoryIds
+            GROUP BY p.id
+            ORDER BY MIN(o.selling_price) ASC
+            """,
+            countQuery = "SELECT COUNT(DISTINCT p.id) FROM products p WHERE p.category_id IN :categoryIds",
+            nativeQuery = true
+    )
+    Page<Product> findByCategoryIdOrderByMinPrice(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
+
+    // 가격정렬 : 최고가격부터
+    @Query(value = """
+            SELECT p.*
+            FROM products p
+            LEFT JOIN product_options o ON p.id = o.product_id
+            WHERE p.category_id IN :categoryIds
+            GROUP BY p.id
+            ORDER BY MIN(o.selling_price) DESC
+            """,
+            countQuery = "SELECT COUNT(DISTINCT p.id) FROM products p WHERE p.category_id IN :categoryIds",
+            nativeQuery = true
+    )
+    Page<Product> findByCategoryIdOrderByMaxPrice(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
+
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
@@ -103,13 +103,40 @@ public class ProductServiceImpl implements ProductService{
     @Override
     public PageResponseDTO<ProductResForList> searchProductsByCategory(List<Long> depth3CategoryIds, PageRequestDTO pageRequest) {
 
-        Pageable pageable = PageRequest.of(
-                pageRequest.getPage()-1,
-                pageRequest.getSize(),
-                Sort.by("id").descending()
-        );
+        Pageable pageable = null;
+        Page<Product> page = null;
 
-        Page<Product> page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
+        if (pageRequest.getSort() == null || pageRequest.getSort().equals("latest")) {
+            pageable = PageRequest.of(
+                    pageRequest.getPage()-1,
+                    pageRequest.getSize(),
+                    Sort.by("id").descending()
+            );
+            page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
+        } else if (pageRequest.getSort().equals("price_asc")) {
+            pageable = PageRequest.of(
+                    pageRequest.getPage()-1,
+                    pageRequest.getSize()
+            );
+            page = productRepository.findByCategoryIdOrderByMinPrice(depth3CategoryIds, pageable);
+
+        } else if (pageRequest.getSort().equals("price_desc")) {
+            pageable = PageRequest.of(
+                    pageRequest.getPage()-1,
+                    pageRequest.getSize()
+            );
+            page = productRepository.findByCategoryIdOrderByMaxPrice(depth3CategoryIds, pageable);
+        } else {
+            // 판매순 (아직 구현 x, 아래는 임시 코드 )
+            pageable = PageRequest.of(
+                    pageRequest.getPage()-1,
+                    pageRequest.getSize(),
+                    Sort.by("id").descending()
+            );
+            page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
+
+        }
+
         List<ProductResForList> dtoList = page.get().map(product -> product.toDTOForList()).toList();
 
         PageResponseDTO<ProductResForList> response = PageResponseDTO.<ProductResForList>withAll()

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/PageRequestDTO.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/review/dto/PageRequestDTO.java
@@ -8,7 +8,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Getter
 @Setter
+@ToString
 public class PageRequestDTO {
     private Integer page;
     private Integer size;
+    private String sort;
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -36,3 +36,14 @@ aws.s3.region=test-dummy
 # ============== PORTONE(?? ??) =============
 portone.rest-api-key:test-dummy
 portone.rest-api-secret:test-dummy
+
+# === CoolSMS (SOLAPI)
+coolsms.api-key=test-dummy
+coolsms.api-secret=test-dummy
+coolsms.sender=test-dummy
+coolsms.enabled=true
+
+# ===== Spring Task Execution Thread Pool Config (Async Thread Pool) ======
+spring.task.execution.pool.core-size=5
+spring.task.execution.pool.max-size=20
+spring.task.execution.pool.queue-capacity=100


### PR DESCRIPTION
- PageRequestDTO : sort 문자열을 받을 수 있도록 필드 추가
- PageRepository : 네이티브쿼리를 이용한 쿼리메서드 작성
  - 가격정렬을 위한 쿼리메서드 2개 작성
  - Products 안에 options 의 최소가격을 이용하여 정렬해야하기 때문에 Group BY 를 써야했다.
  - JPQL 에서는 GROUP BY 를 쓰면 SELECT 하는 컬럼을 모두 GROUP BY 에 넣어야 하므로 네이티브 쿼리를 이용해야 했다.

- ProductServiceImpl :
  - pageRequestDTO 안에 sort 정보에 따라 다른 쿼리메서드로 조회하도록 구현하였다.
  - 아직 가격정보로 정렬하는 쿼리메서드가 없으므로 에러만 나지 않게 최신순 정렬 되도돌 임시코드를 넣어놓음

- application-test.properties : 스프링부트 테스트 통과를 위한 dummy 값 넣어놓음