### PR TITLE
판매순 정렬 기능 구현 및 재고차감, 판매량 증가 로직 추가

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/ProductOption.java
@@ -3,6 +3,7 @@ package kr.kro.moonlightmoist.shopapi.product.domain;
 import jakarta.persistence.*;
 import kr.kro.moonlightmoist.shopapi.common.domain.BaseTimeEntity;
 import kr.kro.moonlightmoist.shopapi.product.dto.ProductOptionDTO;
+import kr.kro.moonlightmoist.shopapi.product.exception.InSufficientStockException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -54,6 +55,17 @@ public class ProductOption extends BaseTimeEntity {
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private boolean deleted = false;
+
+    public void decreaseStock(int quantity) {
+        if (quantity > this.currentStock) {
+            throw new InSufficientStockException(quantity, currentStock);
+        }
+        this.currentStock -= quantity;
+    }
+
+    public void increaseStock(int quantity) {
+        this.currentStock += quantity;
+    }
 
     public void changeOptionName(String name) {
         this.optionName = name;

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/SaleInfo.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/domain/SaleInfo.java
@@ -28,6 +28,15 @@ public class SaleInfo {
     @Column(name = "use_restock_noti", nullable = false)
     private boolean useRestockNoti;
 
+    @Builder.Default
+    @Column(columnDefinition = "integer default 0")
+    private int totalSalesCount = 0;
+
+
+    public void increaseSalesCount(int quantity) {
+        totalSalesCount += quantity;
+    }
+
     public SaleInfoDTO toDTO() {
         return SaleInfoDTO.builder()
                 .exposureStatus(this.exposureStatus)

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/exception/InSufficientStockException.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/exception/InSufficientStockException.java
@@ -1,0 +1,10 @@
+package kr.kro.moonlightmoist.shopapi.product.exception;
+
+public class InSufficientStockException extends RuntimeException {
+    public InSufficientStockException(int requestedQuantity, int currentStock) {
+        super(String.format(
+                "재고가 부족합니다. 요청수량: %d, 현재재고: %d",
+                requestedQuantity, currentStock
+        ));
+    }
+}

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/product/service/ProductServiceImpl.java
@@ -126,15 +126,22 @@ public class ProductServiceImpl implements ProductService{
                     pageRequest.getSize()
             );
             page = productRepository.findByCategoryIdOrderByMaxPrice(depth3CategoryIds, pageable);
-        } else {
-            // 판매순 (아직 구현 x, 아래는 임시 코드 )
+        } else if (pageRequest.getSort().equals("sales")) {
+            // 판매순
             pageable = PageRequest.of(
                     pageRequest.getPage()-1,
                     pageRequest.getSize(),
-                    Sort.by("id").descending()
+                    Sort.by("saleInfo.totalSalesCount").descending()
             );
             page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
-
+        }else {
+            // 인기순 (아직 구현 x, 아래는 임시 코드 )
+            pageable = PageRequest.of(
+                    pageRequest.getPage()-1,
+                    pageRequest.getSize(),
+                    Sort.by("saleInfo.totalSalesCount").descending()
+            );
+            page = productRepository.findByCategoryIdIn(depth3CategoryIds, pageable);
         }
 
         List<ProductResForList> dtoList = page.get().map(product -> product.toDTOForList()).toList();

--- a/src/main/resources/data_crawl.sql
+++ b/src/main/resources/data_crawl.sql
@@ -591,6 +591,11 @@ INSERT INTO products (id, product_detail_info_id, brand_id, category_id, deliver
 (135, 135, 82, 60, 2, FALSE, '[대용량] 에스테덤 하이드라 로션 맥스 400ml', 'NONE', '[대용량] 에스테덤 하이드라 로션 맥스 400ml', 'EXPOSURE', 'ON_SALE', '설명없음', true, false, '2024-05-01 02:26:24', '2024-05-01 02:26:24'),
 (136, 136, 83, 60, 2, FALSE, '[단독기획]에뛰드 순정 약산성 5.5 진정 토너 700ml 대용량 기획(350ml+리필350ml)', 'NONE', '[단독기획]에뛰드 순정 약산성 5.5 진정 토너 700ml 대용량 기획(350ml+리필350ml)', 'EXPOSURE', 'ON_SALE', '설명없음', true, false, '2025-07-29 01:21:47', '2025-07-29 01:21:47');
 
+UPDATE products SET total_sales_count = 5
+WHERE id IN (101, 82, 73, 29, 33, 24);
+
+UPDATE products SET total_sales_count = 10
+WHERE id IN (16, 13, 9, 8);
 
 INSERT INTO product_main_images (product_id, image_type, display_order, image_url) VALUES
 (1, 'THUMBNAIL', 0, 'https://image.oliveyoung.co.kr/cfimages/cf-goods/uploads/images/thumbnails/10/0000/0018/A00000018491610ko.jpg?l=ko&QT=85&SF=webp&sharpen=1x0.5'),


### PR DESCRIPTION
- SaleInfo :  판매순 정렬을 위한 필드 totalSalesCount 생성
- ProductServiceImpl : sort 가 "sales" 로 들어올 시 totalSalesCount 필드로 내림차순 정렬하여 조회하도록 함

- 주문시 상품옵션 재고 차감, 주문취소시 상품옵션 재고 증가 로직 추가
- 현재재고보다 많은 량 주문시 예외 발생
  - 커스텀 예외 InSufficientStockException 정의
- 주문 확정시 판매량 증가 로직 추가