### PR TITLE
[백엔드] 주문 검색 쿼리 생성 관련 코드 수정, dto에 필드 추가, 쿼리문에 코드 추가

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/OrderProduct.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/domain/OrderProduct.java
@@ -57,6 +57,7 @@ public class OrderProduct extends BaseTimeEntity {
                 .imageUrl(this.getProductOption().getProduct().getMainImages().stream().filter(i->i.getImageType()== ImageType.THUMBNAIL).findFirst().get().getImageUrl())
                 .totalAmount(this.getPurchasedPrice()*this.getQuantity())
                 .orderProductStatus(this.getOrderProductStatus())
+                .productId(this.getProductOption().getProduct().getId())
                 .build();
         return orderProductRes;
     }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResBySearch.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/dto/OrderProductResBySearch.java
@@ -22,4 +22,7 @@ public class OrderProductResBySearch {
     private int totalAmount;
     // 상품 주문 상태(주문 접수, 결제 완료, 배송준비중, 배송중, 배송완료, 구매확정)
     private OrderProductStatus orderProductStatus;
+
+    // 상품 id
+    private Long productId;
 }

--- a/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepositoryImpl.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/order/repository/OrderCustomRepositoryImpl.java
@@ -38,7 +38,7 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository{
         // 1. Contents Query (데이터 쿼리) 생성
         // JPQLQuery 객체로 쿼리 본체를 구성
         JPQLQuery<Order> query = queryFactory
-                .selectFrom(order)
+                .selectFrom(order).distinct()
                 .join(order.orderProducts,orderProduct)
                 .join(orderProduct.productOption, productOption)
                 .join(productOption.product, product)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,5 +88,6 @@ portone.rest-api-secret:${PORTONE_REST_API_SECRET}
 # JWT configuration
 jwt.secret=${JWT_SECRET_KEY}
 jwt.expiration=${JWT_SECRET_EXPIRATION}
+
 # Batch process(Query N+1 problem resolve)
 spring.jpa.properties.hibernate.default_batch_fetch_size=100


### PR DESCRIPTION
- 주문 검색 시 쿼리 생성할 때 fetchjoin 제거하고
- application.properties에 Batch 추가
(주문을 N개 생성한다고 가정했을 때, 주문 생성 쿼리 하나에 추가로 주문 상품을 불러오는 쿼리를 N개 생성하므로 N+1개 쿼리가 발생하는데 이때 주문이 많아지게 되면 생성하는 쿼리가 많아져 성능저하가 발생하기 때문에 fetchjoin을 사용하였던 것인데, fetchjoin을 사용하였을 때 관리자 페이지에서 상품명으로 주문 검색할 때, 상품명에 해당되는 주문 상품만 나오고 해당 주문 전체가 나오지 않아서 fetchjoin을 제거하고 성능 저하를 막기 위해 Batch 처리를 하였습니다. Batch는 주문 N개의 주문 상품을 불러오는 쿼리를 생성할 때 N개의 쿼리가 발생하였던 것을 IN 절을 사용함으로써 1개의 쿼리만으로도 여러 주문의 주문 상품을 불러올 수 있습니다.)
- OrderProductResBySearch dto에 productId 필드 추가
- JPQLQuery 객체 생성 코드에 distinct() 메서드 추가
-> distinct() 메서드는 쿼리문으로 불러온 객체가 중복돼 있으면 중복을 제거하고 객체 하나만 남기는 메서드입니다.
