### PR TITLE
[백엔드] 오브젝트매퍼 빈 삭제

### DIFF
--- a/src/main/java/kr/kro/moonlightmoist/shopapi/config/JacksonConfig.java
+++ b/src/main/java/kr/kro/moonlightmoist/shopapi/config/JacksonConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class JacksonConfig {
 
-    @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());


### PR DESCRIPTION
빈 등록하지 않아도 CustomAuthenticationEntryPoint
@Component로 자동 주입

빈 등록했을때 리뷰내역이 오류가 발생
빈을 지웠을땐 정상 작동