### PR TITLE
Github Actions 를 이용한 CI/CD 자동배포 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,35 @@ jobs:
   Deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Github Repository에 올린 파일들을 불러오기
+        uses: actions/checkout@v4
+
+      - name: JDK 17버전 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: application.properties 파일 만들기
+        run: echo "${{ secrets.APPLICATION.PROPERTIES }}" > ./src/main/resources/application.properties
+
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build
+
+      - name: 빌드된 파일 이름 변경하기
+        run: mv ./build/libs/*SNAPSHOT.jar ./project.jar
+
+      - name: SCP로 EC2 에 빌드된 파일 전송하기
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          source: project.jar
+          target: /home/ubuntu/moisture-village-server/tobe
+
       - name: SSH(원격 접속)로 EC2에 접속하기
         uses: appleboy/ssh-action@v1.0.3
-        env:
-          APPLICATION_PROPERTIES: ${{ secrets.APPLICATION_PROPERTIES }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
@@ -20,12 +45,20 @@ jobs:
           envs: APPLICATION_PROPERTIES
           script_stop: true
           script: |
-            cd /home/ubuntu/green-final-shoppingmall-server || exit 1
-            pwd
-            git pull origin main
-            rm -f src/main/resources/application.properties
-            echo "$APPLICATION_PROPERTIES" > src/main/resources/application.properties
-            sudo chmod +x gradlew
-            ./gradlew clean build -x test
+            rm -rf /home/ubuntu/moisture-village-server/current
+            mkdir /home/ubuntu/moisture-village-server/current
+            mv /home/ubuntu/moisture-village-server/tobe/project.jar /home/ubuntu/moisture-village-server/current/project.jar
+            cd /home/ubuntu/moisture-village-server/current
             sudo fuser -k -n tcp 8080 || true
-            nohup java -jar build/libs/*SNAPSHOT.jar > ./output.log 2>&1 &
+            nohup java -jar project.jar > ./output.log 2>&1 &
+            rm -rf /home/ubuntu/moisture-village-server/tobe
+            
+#            cd /home/ubuntu/green-final-shoppingmall-server || exit 1
+#            pwd
+#            git pull origin main
+#            rm -f src/main/resources/application.properties
+#            echo "$APPLICATION_PROPERTIES" > src/main/resources/application.properties
+#            sudo chmod +x gradlew
+#            ./gradlew clean build -x test
+#            sudo fuser -k -n tcp 8080 || true
+#            nohup java -jar build/libs/*SNAPSHOT.jar > ./output.log 2>&1 &


### PR DESCRIPTION
- 기존 자동배포는 ec2 안에서 빌드하고 (테스트는 안함), 배포하는 방식이었으므로 CD 만 적용되었음

- 이제는 Github Actions 에서 테스트를 하면서 빌드를 하고 빌드된 파일을 EC2로 넘겨주고 배포하는 방식으로 변경 : 이로써 CI / CD 를 적용하였음