### PR TITLE
Github Actions 에서 Permission Denied 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: application.properties 파일 만들기
         run: echo "${{ secrets.APPLICATION.PROPERTIES }}" > ./src/main/resources/application.properties
 
+      - name: gradlew 실행 권한 주기
+        run: sudo chmod +x gradlew
+
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build
 


### PR DESCRIPTION
- gradlew 실행 권한이 없어 빌드가 안되고 Permission Denied 가 뜸, 권한 부여 코드를 추가함